### PR TITLE
Created new parser for gpg keys and updated the code to use it

### DIFF
--- a/secureenclave/cli_keycmds.py
+++ b/secureenclave/cli_keycmds.py
@@ -27,7 +27,7 @@ def key_list(ctx, **kwargs):
 
         logger.info("Available GPG Keys:")
         for key in keys:
-            key_type = "Secret" if key.is_secret else "Public"
+            key_type = "Secret" if key.secret_available else "Public"
             logger.info("───────────────────────────────────────────────────────────────────────────")
             logger.info(f"👤 UID: {key.uid}")
             logger.info(f"   Key ID: {key.key_id} ({key_type})")
@@ -44,7 +44,7 @@ def key_list(ctx, **kwargs):
             if key.subkeys:
                 logger.info("   Subkeys:")
                 for subkey in key.subkeys:
-                    subkey_type = "Secret" if subkey.is_secret else "Public"
+                    subkey_type = "Secret" if subkey.secret_available else "Public"
                     logger.info(f"     └─ Subkey ID: {subkey.key_id} ({subkey_type})")
                     logger.info(f"        Fingerprint: {subkey.fingerprint if subkey.fingerprint else 'N/A'}")
                     logger.info(f"        Algorithm: {subkey.algorithm_name} ({subkey.key_length} bits)")

--- a/secureenclave/cli_keycmds.py
+++ b/secureenclave/cli_keycmds.py
@@ -88,10 +88,11 @@ def key_new(ctx, **kwargs):
 @click.command(name='del', help='Delete Key')
 @click_loguru.logging_options
 @click_loguru.init_logger(logfile=False)
+@click.option('--secret', is_flag=True, help='Only delete the secret key, leave the public key.')
 @click.pass_context
-def key_del(ctx, **kwargs):
+def key_del(ctx, secret, **kwargs):
     with SecureEnclave() as secure_enclave:
-        secure_enclave.del_key()
+        secure_enclave.del_key(secret_only=secret)
 
 
 @click.command(name='trust', help='Trust a specific key from the list')

--- a/secureenclave/cli_keycmds.py
+++ b/secureenclave/cli_keycmds.py
@@ -28,16 +28,16 @@ def key_list(ctx, **kwargs):
         logger.info("Available GPG Keys:")
         for key in keys:
             key_type = "Secret" if key.is_secret else "Public"
-            logger.info(f"───────────────────────────────────────────────────────────────────────────")
+            logger.info("───────────────────────────────────────────────────────────────────────────")
             logger.info(f"👤 UID: {key.uid}")
             logger.info(f"   Key ID: {key.key_id} ({key_type})")
             logger.info(f"   Fingerprint: {key.fingerprint if key.fingerprint else 'N/A'}")
             logger.info(f"   Algorithm: {key.algorithm_name} ({key.key_length} bits)")
-            logger.info(f"   Created: {key.creation_date}") # Consider formatting date
+            logger.info(f"   Created: {key.creation_date}")  # Consider formatting date
             if key.expiration_date:
-                logger.info(f"   Expires: {key.expiration_date}") # Consider formatting date
+                logger.info(f"   Expires: {key.expiration_date}")  # Consider formatting date
             else:
-                logger.info(f"   Expires: Never")
+                logger.info("   Expires: Never")
             logger.info(f"   Capabilities: {', '.join(key.capabilities) if key.capabilities else 'N/A'}")
             logger.info(f"   Trust: {key.owner_trust} (UID: {key.uid_validity})")
 
@@ -48,15 +48,15 @@ def key_list(ctx, **kwargs):
                     logger.info(f"     └─ Subkey ID: {subkey.key_id} ({subkey_type})")
                     logger.info(f"        Fingerprint: {subkey.fingerprint if subkey.fingerprint else 'N/A'}")
                     logger.info(f"        Algorithm: {subkey.algorithm_name} ({subkey.key_length} bits)")
-                    logger.info(f"        Created: {subkey.creation_date}") # Consider formatting date
+                    logger.info(f"        Created: {subkey.creation_date}")  # Consider formatting date
                     if subkey.expiration_date:
-                        logger.info(f"        Expires: {subkey.expiration_date}") # Consider formatting date
+                        logger.info(f"        Expires: {subkey.expiration_date}")  # Consider formatting date
                     else:
-                        logger.info(f"        Expires: Never")
+                        logger.info("        Expires: Never")
                     logger.info(f"        Capabilities: {', '.join(subkey.capabilities) if subkey.capabilities else 'N/A'}")
             else:
                 logger.info("   No Subkeys")
-        logger.info(f"───────────────────────────────────────────────────────────────────────────")
+        logger.info("───────────────────────────────────────────────────────────────────────────")
 
 
 @click.command(name='import', help='Import key into keyring')

--- a/secureenclave/cli_keycmds.py
+++ b/secureenclave/cli_keycmds.py
@@ -20,7 +20,43 @@ click_loguru = ClickLoguru(__program__, __version__, stderr_format_func=lambda x
 @click.pass_context
 def key_list(ctx, **kwargs):
     with SecureEnclave() as secure_enclave:
-        secure_enclave.list_keys()
+        keys = secure_enclave.gpg.get_keys()
+        if not keys:
+            logger.info("No GPG keys found in the keyring.")
+            return
+
+        logger.info("Available GPG Keys:")
+        for key in keys:
+            key_type = "Secret" if key.is_secret else "Public"
+            logger.info(f"───────────────────────────────────────────────────────────────────────────")
+            logger.info(f"👤 UID: {key.uid}")
+            logger.info(f"   Key ID: {key.key_id} ({key_type})")
+            logger.info(f"   Fingerprint: {key.fingerprint if key.fingerprint else 'N/A'}")
+            logger.info(f"   Algorithm: {key.algorithm_name} ({key.key_length} bits)")
+            logger.info(f"   Created: {key.creation_date}") # Consider formatting date
+            if key.expiration_date:
+                logger.info(f"   Expires: {key.expiration_date}") # Consider formatting date
+            else:
+                logger.info(f"   Expires: Never")
+            logger.info(f"   Capabilities: {', '.join(key.capabilities) if key.capabilities else 'N/A'}")
+            logger.info(f"   Trust: {key.owner_trust} (UID: {key.uid_validity})")
+
+            if key.subkeys:
+                logger.info("   Subkeys:")
+                for subkey in key.subkeys:
+                    subkey_type = "Secret" if subkey.is_secret else "Public"
+                    logger.info(f"     └─ Subkey ID: {subkey.key_id} ({subkey_type})")
+                    logger.info(f"        Fingerprint: {subkey.fingerprint if subkey.fingerprint else 'N/A'}")
+                    logger.info(f"        Algorithm: {subkey.algorithm_name} ({subkey.key_length} bits)")
+                    logger.info(f"        Created: {subkey.creation_date}") # Consider formatting date
+                    if subkey.expiration_date:
+                        logger.info(f"        Expires: {subkey.expiration_date}") # Consider formatting date
+                    else:
+                        logger.info(f"        Expires: Never")
+                    logger.info(f"        Capabilities: {', '.join(subkey.capabilities) if subkey.capabilities else 'N/A'}")
+            else:
+                logger.info("   No Subkeys")
+        logger.info(f"───────────────────────────────────────────────────────────────────────────")
 
 
 @click.command(name='import', help='Import key into keyring')

--- a/secureenclave/datamodel.py
+++ b/secureenclave/datamodel.py
@@ -50,19 +50,29 @@ class IdentityInfo(object):
 
 @dataclass
 class GpgKey:
-    uid: str
-    pub: str
-    fingerprint: str
-    trust: str
+    uid: str  # User ID string
+    key_id: str  # Key ID
+    fingerprint: Optional[str]  # Key fingerprint
+    uid_validity: str  # Validity of the UID (e.g., "fully valid")
+    owner_trust: Optional[str]  # Owner trust (e.g., "ultimately trusted")
+    algorithm_name: str  # Public key algorithm (e.g., "RSA")
+    key_length: int  # Key length in bits
+    creation_date: int  # Key creation date (timestamp)
+    expiration_date: Optional[int]  # Key expiration date (timestamp)
+    capabilities: List[str]  # Key capabilities (e.g., ["sign", "encrypt"])
+    keygrip: Optional[str]  # Keygrip
 
     def __str__(self):
-        return self.uid.strip()
+        return f"{self.uid} ({self.key_id})"
 
     def __len__(self):
+        # Provides a consistent length representation, perhaps based on UID
         return len(self.uid.strip())
 
     def __add__(self, other):
+        # Concatenation behavior, might need adjustment based on typical use
         return str(self) + other
 
     def __radd__(self, other):
+        # Concatenation behavior, might need adjustment based on typical use
         return other + str(self)

--- a/secureenclave/datamodel.py
+++ b/secureenclave/datamodel.py
@@ -6,7 +6,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, List
 
 
 @dataclass

--- a/secureenclave/datamodel.py
+++ b/secureenclave/datamodel.py
@@ -5,7 +5,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional, List
 
 
@@ -49,18 +49,34 @@ class IdentityInfo(object):
 
 
 @dataclass
-class GpgKey:
-    uid: str
+class GpgSubkey:
     key_id: str
-    fingerprint: Optional[str]
-    uid_validity: str
-    owner_trust: Optional[str]
     algorithm_name: str
     key_length: int
     creation_date: int
     expiration_date: Optional[int]
     capabilities: List[str]
-    keygrip: Optional[str]
+    fingerprint: Optional[str] = None
+    keygrip: Optional[str] = None
+
+    def __str__(self):
+        return f"Subkey({self.key_id}, {self.algorithm_name})"
+
+
+@dataclass
+class GpgKey:
+    uid: str  # User ID string
+    key_id: str  # Primary Key ID
+    fingerprint: Optional[str]  # Primary Key fingerprint
+    uid_validity: str  # Validity of the UID
+    owner_trust: Optional[str]  # Owner trust of the primary key
+    algorithm_name: str  # Primary key algorithm
+    key_length: int  # Primary key length in bits
+    creation_date: int  # Primary key creation date (timestamp)
+    expiration_date: Optional[int]  # Primary key expiration date (timestamp)
+    capabilities: List[str]  # Primary key capabilities
+    keygrip: Optional[str]  # Primary keygrip
+    subkeys: List[GpgSubkey] = field(default_factory=list)  # List of associated subkeys
 
     def __str__(self):
         return f"{self.uid} ({self.key_id})"

--- a/secureenclave/datamodel.py
+++ b/secureenclave/datamodel.py
@@ -50,29 +50,26 @@ class IdentityInfo(object):
 
 @dataclass
 class GpgKey:
-    uid: str  # User ID string
-    key_id: str  # Key ID
-    fingerprint: Optional[str]  # Key fingerprint
-    uid_validity: str  # Validity of the UID (e.g., "fully valid")
-    owner_trust: Optional[str]  # Owner trust (e.g., "ultimately trusted")
-    algorithm_name: str  # Public key algorithm (e.g., "RSA")
-    key_length: int  # Key length in bits
-    creation_date: int  # Key creation date (timestamp)
-    expiration_date: Optional[int]  # Key expiration date (timestamp)
-    capabilities: List[str]  # Key capabilities (e.g., ["sign", "encrypt"])
-    keygrip: Optional[str]  # Keygrip
+    uid: str
+    key_id: str
+    fingerprint: Optional[str]
+    uid_validity: str
+    owner_trust: Optional[str]
+    algorithm_name: str
+    key_length: int
+    creation_date: int
+    expiration_date: Optional[int]
+    capabilities: List[str]
+    keygrip: Optional[str]
 
     def __str__(self):
         return f"{self.uid} ({self.key_id})"
 
     def __len__(self):
-        # Provides a consistent length representation, perhaps based on UID
         return len(self.uid.strip())
 
     def __add__(self, other):
-        # Concatenation behavior, might need adjustment based on typical use
         return str(self) + other
 
     def __radd__(self, other):
-        # Concatenation behavior, might need adjustment based on typical use
         return other + str(self)

--- a/secureenclave/datamodel.py
+++ b/secureenclave/datamodel.py
@@ -58,6 +58,7 @@ class GpgSubkey:
     capabilities: List[str]
     fingerprint: Optional[str] = None
     keygrip: Optional[str] = None
+    is_secret: bool = False
 
     def __str__(self):
         return f"Subkey({self.key_id}, {self.algorithm_name})"
@@ -76,6 +77,7 @@ class GpgKey:
     expiration_date: Optional[int]  # Primary key expiration date (timestamp)
     capabilities: List[str]  # Primary key capabilities
     keygrip: Optional[str]  # Primary keygrip
+    is_secret: bool = False  # True if this primary key has a secret part
     subkeys: List[GpgSubkey] = field(default_factory=list)  # List of associated subkeys
 
     def __str__(self):

--- a/secureenclave/datamodel.py
+++ b/secureenclave/datamodel.py
@@ -58,7 +58,7 @@ class GpgSubkey:
     capabilities: List[str]
     fingerprint: Optional[str] = None
     keygrip: Optional[str] = None
-    is_secret: bool = False
+    secret_available: bool = False
 
     def __str__(self):
         return f"Subkey({self.key_id}, {self.algorithm_name})"
@@ -77,7 +77,7 @@ class GpgKey:
     expiration_date: Optional[int]  # Primary key expiration date (timestamp)
     capabilities: List[str]  # Primary key capabilities
     keygrip: Optional[str]  # Primary keygrip
-    is_secret: bool = False  # True if this primary key has a secret part
+    secret_available: bool = False  # True if the secret part of this primary key is available
     subkeys: List[GpgSubkey] = field(default_factory=list)  # List of associated subkeys
 
     def __str__(self):

--- a/secureenclave/gpg.py
+++ b/secureenclave/gpg.py
@@ -75,15 +75,12 @@ class Gpg(object):
     def getbin(self):
         return self.gpg_bin
 
-    def get_keys(self):
+    def _parse_gpg_list_cmd(self, raw_output: str) -> List[GpgKey]:
         keys: List[GpgKey] = []
-        gpg_cmd = '{} --quiet --list-keys'.format(self.getbin())
-        output = invoke.run(gpg_cmd, env=self.getenv(), pty=True, hide=True)
-        raw = output.stdout  # type: ignore
-        if 'uid  ' in raw:
+        if 'uid  ' in raw_output:
             logger.debug('There is at least a uid in the keylist')
             uid = fingerprint = pub = trust = None
-            for line in raw.splitlines():
+            for line in raw_output.splitlines():
                 if match := re.search('fingerprint[ ]*= ([A-F0-9 ]*)', line):
                     fingerprint = match.group(1).replace(" ", "")
                 if match := re.search('uid (.*)$', line):
@@ -98,6 +95,12 @@ class Gpg(object):
                     keys.append(GpgKey(uid, pub, fingerprint, trust))
                     pub = fingerprint = uid = trust = None
         return keys
+
+    def get_keys(self):
+        gpg_cmd = '{} --quiet --list-keys'.format(self.getbin())
+        output = invoke.run(gpg_cmd, env=self.getenv(), pty=True, hide=True)
+        raw = output.stdout  # type: ignore
+        return self._parse_gpg_list_cmd(raw)
 
     def card_edit(self, attribute, value):
         __content__ = __gpg_card_edit__.format(attribute, value)

--- a/secureenclave/gpg.py
+++ b/secureenclave/gpg.py
@@ -161,12 +161,10 @@ class Gpg(object):
                     # Capabilities might be additive or different, clear and re-add for simplicity
                     primary_keys_info[pk_id]['capabilities'] = []
 
-
                 pk_entry_ref = primary_keys_info[pk_id]
                 if len(fields) > 11 and fields[11]:
                     for char_code in fields[11]:
                         pk_entry_ref['capabilities'].append(GPG_CAPABILITY_MAP.get(char_code, f"unknown_cap_{char_code}"))
-                
                 attachment_target_dict = pk_entry_ref
                 logger.debug(f"Processed {record_type} key: {pk_id}, is_secret: {pk_entry_ref['is_secret']}")
 
@@ -174,7 +172,6 @@ class Gpg(object):
                 if not current_pk_id_active:
                     logger.warning(f"Orphaned subkey record: {line}. Skipping.")
                     continue
-                
                 sk_id = fields[4]
                 is_secret_subkey_record = (record_type == 'ssb')
                 pk_entry_ref = primary_keys_info[current_pk_id_active]
@@ -200,12 +197,10 @@ class Gpg(object):
                     pk_entry_ref['subkeys'][sk_id]['expiration_date'] = int(fields[6]) if fields[6].isdigit() else None
                     pk_entry_ref['subkeys'][sk_id]['capabilities'] = []
 
-
                 sk_entry_ref = pk_entry_ref['subkeys'][sk_id]
-                if len(fields) > 11 and fields[11]: # Subkey capabilities
+                if len(fields) > 11 and fields[11]:  # Subkey capabilities
                     for char_code in fields[11]:
                         sk_entry_ref['capabilities'].append(GPG_CAPABILITY_MAP.get(char_code, f"unknown_cap_{char_code}"))
-                
                 attachment_target_dict = sk_entry_ref
                 logger.debug(f"Processed {record_type} subkey: {sk_id} for pk {current_pk_id_active}, is_secret: {sk_entry_ref['is_secret']}")
 
@@ -215,7 +210,7 @@ class Gpg(object):
                     logger.debug(f"Found fingerprint for {attachment_target_dict.get('key_id')}: {fields[9]}")
                 else:
                     logger.warning(f"Orphaned fingerprint or no attachment target: {line}")
-            
+
             elif record_type == 'grp':
                 if attachment_target_dict and len(fields) > 9:
                     attachment_target_dict['keygrip'] = fields[9]
@@ -235,12 +230,11 @@ class Gpg(object):
                 if not uid_string:
                     logger.warning(f"Skipping UID for key {current_pk_id_active} due to empty UID string. Line: {line}")
                     continue
-                
                 primary_keys_info[current_pk_id_active]['uids'].append({
                     'uid_text': uid_string,
                     'uid_validity': uid_validity,
                 })
-                attachment_target_dict = primary_keys_info[current_pk_id_active] # Reset target to primary key
+                attachment_target_dict = primary_keys_info[current_pk_id_active]  # Reset target to primary key
                 logger.debug(f"Processed UID: '{uid_string}' for pk {current_pk_id_active}")
 
         # Construct final GpgKey objects
@@ -249,14 +243,12 @@ class Gpg(object):
             subkeys_obj_list: List[GpgSubkey] = []
             for sk_id, sk_data_dict in pk_data_dict.get('subkeys', {}).items():
                 subkeys_obj_list.append(GpgSubkey(**sk_data_dict))
-            
             # Create a GpgKey object for each UID associated with this primary key
             if not pk_data_dict.get('uids'):
-                 logger.warning(f"Primary key {pk_id} has no UIDs. Skipping GpgKey object creation for it directly, though its subkeys are parsed.")
+                logger.warning(f"Primary key {pk_id} has no UIDs. Skipping GpgKey object creation for it directly, though its subkeys are parsed.")
             for uid_info in pk_data_dict.get('uids', []):
                 # Prepare pk_data_dict for GpgKey constructor by removing non-GpgKey fields
                 constructor_pk_data = {k: v for k, v in pk_data_dict.items() if k not in ['uids', 'subkeys']}
-                
                 gpg_key_obj = GpgKey(
                     uid=uid_info['uid_text'],
                     uid_validity=uid_info['uid_validity'],
@@ -264,12 +256,10 @@ class Gpg(object):
                     **constructor_pk_data
                 )
                 final_gpg_keys.append(gpg_key_obj)
-        
         if not final_gpg_keys and raw_output:
             logger.debug("No GPG keys with UIDs were fully parsed from GPG output.")
         elif not raw_output:
             logger.debug("GPG output was empty.")
-            
         return final_gpg_keys
 
     def get_keys(self) -> List[GpgKey]:

--- a/secureenclave/gpg.py
+++ b/secureenclave/gpg.py
@@ -13,7 +13,7 @@ from io import StringIO
 import urllib.parse
 
 from loguru import logger
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Tuple
 
 from secureenclave.datamodel import GpgKey, GpgSubkey
 
@@ -151,7 +151,7 @@ class Gpg(object):
                     }
                 # If key already exists, update its secret_available status if this is a secret key record
                 elif is_secret_record:
-                   primary_keys_info[pk_id]['secret_available'] = True
+                    primary_keys_info[pk_id]['secret_available'] = True
 
                 if not is_secret_record and primary_keys_info[pk_id].get('secret_available', False):
                     pass
@@ -310,7 +310,7 @@ class Gpg(object):
                 # This secret key (and its subkeys) was not in public_keys list. Add it directly.
                 # All its secret_available flags are already True.
                 merged_keys_map[key_tuple] = sec_key
-            
+
         return list(merged_keys_map.values())
 
     def get_keys(self) -> List[GpgKey]:

--- a/secureenclave/gpg.py
+++ b/secureenclave/gpg.py
@@ -47,11 +47,9 @@ keytocard
 save
 """
 
-# Mappings for GPG --with-colons output
 GPG_ALGORITHM_NAME_MAP: Dict[str, str] = {
     "1": "RSA", "2": "RSA-E", "3": "RSA-S", "16": "ELG-E", "17": "DSA",
     "18": "ECC", "19": "ECDSA", "20": "ELG", "21": "PAD", "22": "EDDSA",
-    # Add others as needed
 }
 
 GPG_VALIDITY_MAP: Dict[str, str] = {
@@ -67,19 +65,19 @@ GPG_VALIDITY_MAP: Dict[str, str] = {
     'f': "fully valid",
     'u': "ultimately valid",
     's': "special validity",
-    'w': "well-known public key",  # GnuPG specific
+    'w': "well-known public key", 
 }
 
 GPG_OWNERTRUST_MAP: Dict[str, str] = {
     '-': "unknown",
-    'o': "unknown",  # GnuPG specific for "not enough information"
+    'o': "unknown",
     'q': "undefined",
     'n': "not trusted",
     'm': "marginally trusted",
     'f': "fully trusted",
     'u': "ultimately trusted",
-    'e': "expired",  # GnuPG specific for expired trust signature
-    'r': "revoked",  # GnuPG specific for revoked trust signature
+    'e': "expired",
+    'r': "revoked",
 }
 
 GPG_CAPABILITY_MAP: Dict[str, str] = {
@@ -87,7 +85,7 @@ GPG_CAPABILITY_MAP: Dict[str, str] = {
     's': "sign",
     'c': "certify",
     'a': "authenticate",
-    't': "set-primary-uid",  # GnuPG specific, often on self-signatures
+    't': "set-primary-uid",
     '?': "unknown"
 }
 
@@ -129,9 +127,7 @@ class Gpg(object):
                 continue
 
             record_type = fields[0]
-
             if record_type == 'pub':
-                # Start of a new public key block
                 current_key_details = {
                     'key_id': fields[4],
                     'algorithm_name': GPG_ALGORITHM_NAME_MAP.get(fields[3], f"unknown_algo_{fields[3]}"),
@@ -140,8 +136,8 @@ class Gpg(object):
                     'expiration_date': int(fields[6]) if fields[6].isdigit() else None,
                     'owner_trust': GPG_OWNERTRUST_MAP.get(fields[8], "unknown") if len(fields) > 8 else "unknown",
                     'capabilities': [],
-                    'fingerprint': None,  # Will be filled by 'fpr' record
-                    'keygrip': None,      # Will be filled by 'grp' record
+                    'fingerprint': None,
+                    'keygrip': None,
                 }
                 # Parse capabilities from field 11 (e.g., "scea")
                 if len(fields) > 11 and fields[11]:
@@ -150,19 +146,16 @@ class Gpg(object):
                 logger.debug(f"Parsing pub key: {current_key_details['key_id']}")
 
             elif record_type == 'fpr' and current_key_details:
-                # Fingerprint for the current key
                 if len(fields) > 9:
                     current_key_details['fingerprint'] = fields[9]
                     logger.debug(f"Found fingerprint for {current_key_details.get('key_id')}: {fields[9]}")
 
             elif record_type == 'grp' and current_key_details:
-                # Keygrip for the current key
                 if len(fields) > 9:
                     current_key_details['keygrip'] = fields[9]
                     logger.debug(f"Found keygrip for {current_key_details.get('key_id')}: {fields[9]}")
 
             elif record_type == 'uid' and current_key_details and 'key_id' in current_key_details:
-                # User ID for the current key
                 uid_string = ""
                 if len(fields) > 9:  # GnuPG 2.1+ format
                     uid_string = urllib.parse.unquote_plus(fields[9])
@@ -172,7 +165,7 @@ class Gpg(object):
                 uid_validity_char = fields[1]
                 uid_validity = GPG_VALIDITY_MAP.get(uid_validity_char, "unknown validity")
 
-                if not uid_string:  # Skip if UID string is empty
+                if not uid_string:
                     logger.warning(f"Skipping UID for key {current_key_details['key_id']} due to empty UID string. Line: {line}")
                     continue
 

--- a/secureenclave/gpg.py
+++ b/secureenclave/gpg.py
@@ -164,9 +164,14 @@ class Gpg(object):
                 primary_keys_info[pk_id]['algorithm_name'] = GPG_ALGORITHM_NAME_MAP.get(fields[3], f"unknown_algo_{fields[3]}")
                 primary_keys_info[pk_id]['key_length'] = int(fields[2]) if fields[2].isdigit() else 0
                 primary_keys_info[pk_id]['creation_date'] = int(fields[5]) if fields[5].isdigit() else 0
-                    primary_keys_info[pk_id]['expiration_date'] = int(fields[6]) if fields[6].isdigit() else None
-                    primary_keys_info[pk_id]['owner_trust'] = GPG_OWNERTRUST_MAP.get(fields[8], "unknown") if len(fields) > 8 else "unknown"
-                    primary_keys_info[pk_id]['capabilities'] = []
+                primary_keys_info[pk_id]['expiration_date'] = int(fields[6]) if fields[6].isdigit() else None
+                primary_keys_info[pk_id]['owner_trust'] = GPG_OWNERTRUST_MAP.get(fields[8], "unknown") if len(fields) > 8 else "unknown"
+                # Note: 'capabilities' is cleared and re-populated a few lines below,
+                # so initializing it here might be redundant if that logic is intended to always run.
+                # However, to match the previous structure before the faulty indentation,
+                # we can keep it or remove it if the subsequent re-population is guaranteed.
+                # For now, let's assume the re-population is the primary source.
+                # primary_keys_info[pk_id]['capabilities'] = [] # This line was present before, but might be overwritten
 
                 pk_entry_ref = primary_keys_info[pk_id]
                 # Clear and re-populate capabilities, as they might differ if pub/sec records are processed sequentially for the same key

--- a/secureenclave/gpg.py
+++ b/secureenclave/gpg.py
@@ -9,12 +9,11 @@ import os
 import sys
 import shutil
 import invoke
-import re
 from io import StringIO
 import urllib.parse
 
 from loguru import logger
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any
 
 from secureenclave.datamodel import GpgKey
 
@@ -68,19 +67,19 @@ GPG_VALIDITY_MAP: Dict[str, str] = {
     'f': "fully valid",
     'u': "ultimately valid",
     's': "special validity",
-    'w': "well-known public key", # GnuPG specific
+    'w': "well-known public key",  # GnuPG specific
 }
 
 GPG_OWNERTRUST_MAP: Dict[str, str] = {
     '-': "unknown",
-    'o': "unknown", # GnuPG specific for "not enough information"
+    'o': "unknown",  # GnuPG specific for "not enough information"
     'q': "undefined",
     'n': "not trusted",
     'm': "marginally trusted",
     'f': "fully trusted",
     'u': "ultimately trusted",
-    'e': "expired", # GnuPG specific for expired trust signature
-    'r': "revoked", # GnuPG specific for revoked trust signature
+    'e': "expired",  # GnuPG specific for expired trust signature
+    'r': "revoked",  # GnuPG specific for revoked trust signature
 }
 
 GPG_CAPABILITY_MAP: Dict[str, str] = {
@@ -88,7 +87,7 @@ GPG_CAPABILITY_MAP: Dict[str, str] = {
     's': "sign",
     'c': "certify",
     'a': "authenticate",
-    't': "set-primary-uid", # GnuPG specific, often on self-signatures
+    't': "set-primary-uid",  # GnuPG specific, often on self-signatures
     '?': "unknown"
 }
 
@@ -141,8 +140,8 @@ class Gpg(object):
                     'expiration_date': int(fields[6]) if fields[6].isdigit() else None,
                     'owner_trust': GPG_OWNERTRUST_MAP.get(fields[8], "unknown") if len(fields) > 8 else "unknown",
                     'capabilities': [],
-                    'fingerprint': None, # Will be filled by 'fpr' record
-                    'keygrip': None,     # Will be filled by 'grp' record
+                    'fingerprint': None,  # Will be filled by 'fpr' record
+                    'keygrip': None,      # Will be filled by 'grp' record
                 }
                 # Parse capabilities from field 11 (e.g., "scea")
                 if len(fields) > 11 and fields[11]:
@@ -156,7 +155,6 @@ class Gpg(object):
                     current_key_details['fingerprint'] = fields[9]
                     logger.debug(f"Found fingerprint for {current_key_details.get('key_id')}: {fields[9]}")
 
-
             elif record_type == 'grp' and current_key_details:
                 # Keygrip for the current key
                 if len(fields) > 9:
@@ -166,16 +164,15 @@ class Gpg(object):
             elif record_type == 'uid' and current_key_details and 'key_id' in current_key_details:
                 # User ID for the current key
                 uid_string = ""
-                if len(fields) > 9: # GnuPG 2.1+ format
+                if len(fields) > 9:  # GnuPG 2.1+ format
                     uid_string = urllib.parse.unquote_plus(fields[9])
-                elif len(fields) > 7: # Older GnuPG format might have UID in field 7
-                     uid_string = urllib.parse.unquote_plus(fields[7])
-
+                elif len(fields) > 7:  # Older GnuPG format might have UID in field 7
+                    uid_string = urllib.parse.unquote_plus(fields[7])
 
                 uid_validity_char = fields[1]
                 uid_validity = GPG_VALIDITY_MAP.get(uid_validity_char, "unknown validity")
 
-                if not uid_string: # Skip if UID string is empty
+                if not uid_string:  # Skip if UID string is empty
                     logger.warning(f"Skipping UID for key {current_key_details['key_id']} due to empty UID string. Line: {line}")
                     continue
 
@@ -195,7 +192,7 @@ class Gpg(object):
                 keys_list.append(gpg_key)
                 logger.debug(f"Added GpgKey: {uid_string} for key {current_key_details['key_id']}")
 
-            elif record_type in ('sub', 'ssb'): # Subkey, reset current_key_details to avoid associating UIDs with subkeys
+            elif record_type in ('sub', 'ssb'):  # Subkey, reset current_key_details to avoid associating UIDs with subkeys
                 # For now, we are not parsing subkeys into GpgKey objects in this list.
                 # If subkeys were to be listed, they'd need their own 'fpr', 'grp' etc.
                 # Resetting current_key_details ensures subsequent UIDs are not wrongly associated.
@@ -204,7 +201,6 @@ class Gpg(object):
                 # For safety, we can clear parts that are subkey-specific if we were to process them.
                 # For now, we assume UIDs always belong to the last 'pub' key.
                 pass
-
 
         if not keys_list and raw_output:
             logger.debug("No keys found or parsed from GPG output.")
@@ -221,8 +217,8 @@ class Gpg(object):
         logger.debug(f"Executing GPG command: {gpg_cmd}")
         try:
             # pty=True is generally not recommended for machine-readable output
-            output = invoke.run(gpg_cmd, env=self.getenv(), hide=True, warn=True) # warn=True to catch errors
-            output.raise_for_status() # Raise HTTPError for bad responses (4xx or 5xx)
+            output = invoke.run(gpg_cmd, env=self.getenv(), hide=True, warn=True)  # warn=True to catch errors
+            output.raise_for_status()  # Raise HTTPError for bad responses (4xx or 5xx)
             raw: str = output.stdout
             logger.trace(f"Raw GPG output:\n{raw}")
             return self._parse_gpg_list_cmd(raw)
@@ -230,11 +226,10 @@ class Gpg(object):
             logger.error(f"GPG command failed: {e.result.command}")
             logger.error(f"GPG stderr: {e.result.stderr}")
             logger.error(f"GPG stdout: {e.result.stdout}")
-            return [] # Return empty list on error
+            return []  # Return empty list on error
         except Exception as e:
             logger.error(f"An unexpected error occurred while getting GPG keys: {e}")
             return []
-
 
     def card_edit(self, attribute, value):
         __content__ = __gpg_card_edit__.format(attribute, value)

--- a/secureenclave/gpg.py
+++ b/secureenclave/gpg.py
@@ -118,9 +118,9 @@ class Gpg(object):
         return self.gpg_bin
 
     def _parse_gpg_list_cmd(self, raw_output: str) -> List[GpgKey]:
-        parsed_keys: List[GpgKey] = []
-        current_primary_key_data: Optional[Dict[str, Any]] = None
-        attachment_target: Optional[Dict[str, Any]] = None
+        primary_keys_info: Dict[str, Dict[str, Any]] = {}
+        current_pk_id_active: Optional[str] = None
+        attachment_target_dict: Optional[Dict[str, Any]] = None
 
         for line in raw_output.splitlines():
             fields = line.strip().split(':')
@@ -129,69 +129,103 @@ class Gpg(object):
 
             record_type = fields[0]
 
-            if record_type == 'pub':
-                current_primary_key_data = {
-                    'key_id': fields[4],
-                    'algorithm_name': GPG_ALGORITHM_NAME_MAP.get(fields[3], f"unknown_algo_{fields[3]}"),
-                    'key_length': int(fields[2]) if fields[2].isdigit() else 0,
-                    'creation_date': int(fields[5]) if fields[5].isdigit() else 0,
-                    'expiration_date': int(fields[6]) if fields[6].isdigit() else None,
-                    'owner_trust': GPG_OWNERTRUST_MAP.get(fields[8], "unknown") if len(fields) > 8 else "unknown",
-                    'capabilities': [],
-                    'fingerprint': None,
-                    'keygrip': None,
-                    'subkeys': [],
-                }
-                attachment_target = current_primary_key_data
-                # Parse capabilities from field 11 (e.g., "scea")
+            if record_type in ('pub', 'sec'):
+                pk_id = fields[4]
+                current_pk_id_active = pk_id
+                is_secret_record = (record_type == 'sec')
+
+                if pk_id not in primary_keys_info:
+                    primary_keys_info[pk_id] = {
+                        'key_id': pk_id,
+                        'algorithm_name': GPG_ALGORITHM_NAME_MAP.get(fields[3], f"unknown_algo_{fields[3]}"),
+                        'key_length': int(fields[2]) if fields[2].isdigit() else 0,
+                        'creation_date': int(fields[5]) if fields[5].isdigit() else 0,
+                        'expiration_date': int(fields[6]) if fields[6].isdigit() else None,
+                        'owner_trust': GPG_OWNERTRUST_MAP.get(fields[8], "unknown") if len(fields) > 8 else "unknown",
+                        'capabilities': [],
+                        'fingerprint': None,
+                        'keygrip': None,
+                        'is_secret': is_secret_record,
+                        'uids': [],
+                        'subkeys': {},  # Stores subkey data dicts, keyed by subkey_id
+                    }
+                else:
+                    # Update existing entry, especially is_secret
+                    primary_keys_info[pk_id]['is_secret'] = primary_keys_info[pk_id]['is_secret'] or is_secret_record
+                    # Re-parse fields that might differ or be more complete in a 'sec' record (though usually not)
+                    primary_keys_info[pk_id]['algorithm_name'] = GPG_ALGORITHM_NAME_MAP.get(fields[3], f"unknown_algo_{fields[3]}")
+                    primary_keys_info[pk_id]['key_length'] = int(fields[2]) if fields[2].isdigit() else 0
+                    primary_keys_info[pk_id]['creation_date'] = int(fields[5]) if fields[5].isdigit() else 0
+                    primary_keys_info[pk_id]['expiration_date'] = int(fields[6]) if fields[6].isdigit() else None
+                    primary_keys_info[pk_id]['owner_trust'] = GPG_OWNERTRUST_MAP.get(fields[8], "unknown") if len(fields) > 8 else "unknown"
+                    # Capabilities might be additive or different, clear and re-add for simplicity
+                    primary_keys_info[pk_id]['capabilities'] = []
+
+
+                pk_entry_ref = primary_keys_info[pk_id]
                 if len(fields) > 11 and fields[11]:
                     for char_code in fields[11]:
-                        current_primary_key_data['capabilities'].append(GPG_CAPABILITY_MAP.get(char_code, f"unknown_cap_{char_code}"))
-                logger.debug(f"Parsing pub key: {current_primary_key_data['key_id']}")
+                        pk_entry_ref['capabilities'].append(GPG_CAPABILITY_MAP.get(char_code, f"unknown_cap_{char_code}"))
+                
+                attachment_target_dict = pk_entry_ref
+                logger.debug(f"Processed {record_type} key: {pk_id}, is_secret: {pk_entry_ref['is_secret']}")
 
             elif record_type in ('sub', 'ssb'):
-                if not current_primary_key_data:
-                    logger.warning(f"Orphaned subkey record found: {line}. Skipping.")
+                if not current_pk_id_active:
+                    logger.warning(f"Orphaned subkey record: {line}. Skipping.")
                     continue
+                
+                sk_id = fields[4]
+                is_secret_subkey_record = (record_type == 'ssb')
+                pk_entry_ref = primary_keys_info[current_pk_id_active]
 
-                subkey_caps = []
-                if len(fields) > 11 and fields[11]:
+                if sk_id not in pk_entry_ref['subkeys']:
+                    pk_entry_ref['subkeys'][sk_id] = {
+                        'key_id': sk_id,
+                        'algorithm_name': GPG_ALGORITHM_NAME_MAP.get(fields[3], f"unknown_algo_{fields[3]}"),
+                        'key_length': int(fields[2]) if fields[2].isdigit() else 0,
+                        'creation_date': int(fields[5]) if fields[5].isdigit() else 0,
+                        'expiration_date': int(fields[6]) if fields[6].isdigit() else None,
+                        'capabilities': [],
+                        'fingerprint': None,
+                        'keygrip': None,
+                        'is_secret': is_secret_subkey_record,
+                    }
+                else:
+                    pk_entry_ref['subkeys'][sk_id]['is_secret'] = pk_entry_ref['subkeys'][sk_id]['is_secret'] or is_secret_subkey_record
+                    # Re-parse fields for subkey
+                    pk_entry_ref['subkeys'][sk_id]['algorithm_name'] = GPG_ALGORITHM_NAME_MAP.get(fields[3], f"unknown_algo_{fields[3]}")
+                    pk_entry_ref['subkeys'][sk_id]['key_length'] = int(fields[2]) if fields[2].isdigit() else 0
+                    pk_entry_ref['subkeys'][sk_id]['creation_date'] = int(fields[5]) if fields[5].isdigit() else 0
+                    pk_entry_ref['subkeys'][sk_id]['expiration_date'] = int(fields[6]) if fields[6].isdigit() else None
+                    pk_entry_ref['subkeys'][sk_id]['capabilities'] = []
+
+
+                sk_entry_ref = pk_entry_ref['subkeys'][sk_id]
+                if len(fields) > 11 and fields[11]: # Subkey capabilities
                     for char_code in fields[11]:
-                        subkey_caps.append(GPG_CAPABILITY_MAP.get(char_code, f"unknown_cap_{char_code}"))
-
-                current_subkey_dict = {
-                    'key_id': fields[4],
-                    'algorithm_name': GPG_ALGORITHM_NAME_MAP.get(fields[3], f"unknown_algo_{fields[3]}"),
-                    'key_length': int(fields[2]) if fields[2].isdigit() else 0,
-                    'creation_date': int(fields[5]) if fields[5].isdigit() else 0,
-                    'expiration_date': int(fields[6]) if fields[6].isdigit() else None,
-                    'capabilities': subkey_caps,
-                    'fingerprint': None,
-                    'keygrip': None,
-                }
-                current_primary_key_data['subkeys'].append(current_subkey_dict)
-                attachment_target = current_subkey_dict
-                logger.debug(f"Parsing subkey: {current_subkey_dict['key_id']} for pub {current_primary_key_data['key_id']}")
+                        sk_entry_ref['capabilities'].append(GPG_CAPABILITY_MAP.get(char_code, f"unknown_cap_{char_code}"))
+                
+                attachment_target_dict = sk_entry_ref
+                logger.debug(f"Processed {record_type} subkey: {sk_id} for pk {current_pk_id_active}, is_secret: {sk_entry_ref['is_secret']}")
 
             elif record_type == 'fpr':
-                if attachment_target and len(fields) > 9:
-                    fingerprint_val = fields[9]
-                    attachment_target['fingerprint'] = fingerprint_val
-                    logger.debug(f"Found fingerprint for {attachment_target.get('key_id')}: {fingerprint_val}")
+                if attachment_target_dict and len(fields) > 9:
+                    attachment_target_dict['fingerprint'] = fields[9]
+                    logger.debug(f"Found fingerprint for {attachment_target_dict.get('key_id')}: {fields[9]}")
                 else:
-                    logger.warning(f"Orphaned fingerprint record or missing target: {line}")
-
+                    logger.warning(f"Orphaned fingerprint or no attachment target: {line}")
+            
             elif record_type == 'grp':
-                if attachment_target and len(fields) > 9:
-                    keygrip_val = fields[9]
-                    attachment_target['keygrip'] = keygrip_val
-                    logger.debug(f"Found keygrip for {attachment_target.get('key_id')}: {keygrip_val}")
+                if attachment_target_dict and len(fields) > 9:
+                    attachment_target_dict['keygrip'] = fields[9]
+                    logger.debug(f"Found keygrip for {attachment_target_dict.get('key_id')}: {fields[9]}")
                 else:
-                    logger.warning(f"Orphaned keygrip record or missing target: {line}")
+                    logger.warning(f"Orphaned keygrip or no attachment target: {line}")
 
             elif record_type == 'uid':
-                if not current_primary_key_data:
-                    logger.warning(f"Orphaned UID record found: {line}. Skipping.")
+                if not current_pk_id_active:
+                    logger.warning(f"Orphaned UID record: {line}. Skipping.")
                     continue
 
                 uid_string = urllib.parse.unquote_plus(fields[9]) if len(fields) > 9 else ""
@@ -199,40 +233,47 @@ class Gpg(object):
                 uid_validity = GPG_VALIDITY_MAP.get(uid_validity_char, "unknown validity")
 
                 if not uid_string:
-                    logger.warning(f"Skipping UID for key {current_primary_key_data['key_id']} due to empty UID string. Line: {line}")
+                    logger.warning(f"Skipping UID for key {current_pk_id_active} due to empty UID string. Line: {line}")
                     continue
+                
+                primary_keys_info[current_pk_id_active]['uids'].append({
+                    'uid_text': uid_string,
+                    'uid_validity': uid_validity,
+                })
+                attachment_target_dict = primary_keys_info[current_pk_id_active] # Reset target to primary key
+                logger.debug(f"Processed UID: '{uid_string}' for pk {current_pk_id_active}")
 
-                subkeys_list = []
-                for sub_dict in current_primary_key_data.get('subkeys', []):
-                    subkeys_list.append(GpgSubkey(**sub_dict))
-
-                gpg_key = GpgKey(
-                    uid=uid_string,
-                    key_id=current_primary_key_data['key_id'],
-                    fingerprint=current_primary_key_data.get('fingerprint'),
-                    uid_validity=uid_validity,
-                    owner_trust=current_primary_key_data.get('owner_trust'),
-                    algorithm_name=current_primary_key_data['algorithm_name'],
-                    key_length=current_primary_key_data['key_length'],
-                    creation_date=current_primary_key_data['creation_date'],
-                    expiration_date=current_primary_key_data.get('expiration_date'),
-                    capabilities=current_primary_key_data.get('capabilities', []),
-                    keygrip=current_primary_key_data.get('keygrip'),
-                    subkeys=subkeys_list
+        # Construct final GpgKey objects
+        final_gpg_keys: List[GpgKey] = []
+        for pk_id, pk_data_dict in primary_keys_info.items():
+            subkeys_obj_list: List[GpgSubkey] = []
+            for sk_id, sk_data_dict in pk_data_dict.get('subkeys', {}).items():
+                subkeys_obj_list.append(GpgSubkey(**sk_data_dict))
+            
+            # Create a GpgKey object for each UID associated with this primary key
+            if not pk_data_dict.get('uids'):
+                 logger.warning(f"Primary key {pk_id} has no UIDs. Skipping GpgKey object creation for it directly, though its subkeys are parsed.")
+            for uid_info in pk_data_dict.get('uids', []):
+                # Prepare pk_data_dict for GpgKey constructor by removing non-GpgKey fields
+                constructor_pk_data = {k: v for k, v in pk_data_dict.items() if k not in ['uids', 'subkeys']}
+                
+                gpg_key_obj = GpgKey(
+                    uid=uid_info['uid_text'],
+                    uid_validity=uid_info['uid_validity'],
+                    subkeys=subkeys_obj_list,
+                    **constructor_pk_data
                 )
-                parsed_keys.append(gpg_key)
-                logger.debug(f"Added GpgKey: {uid_string} for key {current_primary_key_data['key_id']} with {len(subkeys_list)} subkeys")
-                attachment_target = current_primary_key_data
-
-        if not parsed_keys and raw_output:
-            logger.debug("No keys found or parsed from GPG output.")
+                final_gpg_keys.append(gpg_key_obj)
+        
+        if not final_gpg_keys and raw_output:
+            logger.debug("No GPG keys with UIDs were fully parsed from GPG output.")
         elif not raw_output:
             logger.debug("GPG output was empty.")
-
-        return parsed_keys
+            
+        return final_gpg_keys
 
     def get_keys(self) -> List[GpgKey]:
-        gpg_cmd = f'{self.getbin()} --with-colons --fixed-list-mode --with-fingerprint --list-keys'
+        gpg_cmd = f'{self.getbin()} --with-colons --fixed-list-mode --with-fingerprint --list-keys --list-secret-keys'
         logger.debug(f"Executing GPG command: {gpg_cmd}")
         try:
             output = invoke.run(gpg_cmd, env=self.getenv(), hide=True, warn=True)

--- a/secureenclave/gpg.py
+++ b/secureenclave/gpg.py
@@ -267,13 +267,59 @@ class Gpg(object):
             logger.debug("GPG output was empty.")
         return final_gpg_keys
 
+    def _dedup_keys(self, public_keys: List[GpgKey], secret_keys: List[GpgKey]) -> List[GpgKey]:
+        """
+        Merges lists of public and secret GPG keys.
+
+        Prioritizes information from secret_keys (e.g., secret_available=True)
+        when a key exists in both lists.
+        """
+        merged_keys_map: Dict[Tuple[str, str], GpgKey] = {}
+
+        # First, add all public keys. Their secret_available flags are False by default
+        # as parsed by _parse_gpg_list_cmd when called with --list-keys output.
+        for pub_key in public_keys:
+            key_tuple = (pub_key.key_id, pub_key.uid)
+            merged_keys_map[key_tuple] = pub_key
+
+        # Now, process secret keys.
+        # If a key exists from public_keys, update its secret_available status.
+        # If it doesn't exist, add the secret key (all its flags are already True).
+        for sec_key in secret_keys:
+            key_tuple = (sec_key.key_id, sec_key.uid)
+            if key_tuple in merged_keys_map:
+                # Key already exists from public_keys list. Update its secret_available flags.
+                existing_key = merged_keys_map[key_tuple]
+                existing_key.secret_available = True  # sec_key has this True
+
+                # Create a map of existing subkeys for quick lookup and update
+                existing_subkeys_map: Dict[str, GpgSubkey] = {
+                    subkey.key_id: subkey for subkey in existing_key.subkeys
+                }
+
+                for sec_subkey in sec_key.subkeys:
+                    if sec_subkey.key_id in existing_subkeys_map:
+                        # Subkey exists, update its secret_available flag
+                        # sec_subkey from secret_keys list has secret_available=True
+                        existing_subkeys_map[sec_subkey.key_id].secret_available = True
+                    else:
+                        # This secret subkey was not in the public key's subkey list. Add it.
+                        # Its secret_available is already True from parsing secret_keys.
+                        existing_key.subkeys.append(sec_subkey)
+            else:
+                # This secret key (and its subkeys) was not in public_keys list. Add it directly.
+                # All its secret_available flags are already True.
+                merged_keys_map[key_tuple] = sec_key
+            
+        return list(merged_keys_map.values())
+
     def get_keys(self) -> List[GpgKey]:
         command = f'{self.getbin()} --with-colons --fixed-list-mode --with-fingerprint --list-keys'
         output = invoke.run(command=command, env=self.getenv(), hide=True, warn=True)
-        public_keys = self._parse_gpg_list_cmd(output.raw_output)
+        public_keys = self._parse_gpg_list_cmd(output.stdout)
         command = f'{self.getbin()} --with-colons --fixed-list-mode --with-fingerprint --list-secret-keys'
         output = invoke.run(command=command, env=self.getenv(), hide=True, warn=True)
-        secret_keys = self._parse_gpg_list_cmd(output.raw_output)
+        secret_keys = self._parse_gpg_list_cmd(output.stdout)
         keys = self._dedup_keys(public_keys, secret_keys)
         return keys
 

--- a/secureenclave/gpg.py
+++ b/secureenclave/gpg.py
@@ -120,7 +120,6 @@ class Gpg(object):
     def _parse_gpg_list_cmd(self, raw_output: str) -> List[GpgKey]:
         parsed_keys: List[GpgKey] = []
         current_primary_key_data: Optional[Dict[str, Any]] = None
-        # attachment_target points to the dict (primary or subkey) that should receive next fpr/grp
         attachment_target: Optional[Dict[str, Any]] = None
 
         for line in raw_output.splitlines():
@@ -141,7 +140,7 @@ class Gpg(object):
                     'capabilities': [],
                     'fingerprint': None,
                     'keygrip': None,
-                    'subkeys': [],  # Stores raw subkey dictionaries
+                    'subkeys': [],
                 }
                 attachment_target = current_primary_key_data
                 # Parse capabilities from field 11 (e.g., "scea")
@@ -203,7 +202,6 @@ class Gpg(object):
                     logger.warning(f"Skipping UID for key {current_primary_key_data['key_id']} due to empty UID string. Line: {line}")
                     continue
 
-                # Convert raw subkey dicts to GpgSubkey objects
                 subkeys_list = []
                 for sub_dict in current_primary_key_data.get('subkeys', []):
                     subkeys_list.append(GpgSubkey(**sub_dict))
@@ -224,8 +222,6 @@ class Gpg(object):
                 )
                 parsed_keys.append(gpg_key)
                 logger.debug(f"Added GpgKey: {uid_string} for key {current_primary_key_data['key_id']} with {len(subkeys_list)} subkeys")
-                # After a UID, subsequent fpr/grp should ideally target the primary key again
-                # if they appear before a new 'sub' or 'pub'.
                 attachment_target = current_primary_key_data
 
         if not parsed_keys and raw_output:
@@ -236,15 +232,11 @@ class Gpg(object):
         return parsed_keys
 
     def get_keys(self) -> List[GpgKey]:
-        # Use --with-colons for machine-readable output
-        # --fixed-list-mode helps stabilize output across GPG versions
-        # --with-fingerprint ensures fingerprints are included
         gpg_cmd = f'{self.getbin()} --with-colons --fixed-list-mode --with-fingerprint --list-keys'
         logger.debug(f"Executing GPG command: {gpg_cmd}")
         try:
-            # pty=True is generally not recommended for machine-readable output
-            output = invoke.run(gpg_cmd, env=self.getenv(), hide=True, warn=True)  # warn=True to catch errors
-            output.raise_for_status()  # Raise HTTPError for bad responses (4xx or 5xx)
+            output = invoke.run(gpg_cmd, env=self.getenv(), hide=True, warn=True)
+            output.raise_for_status()
             raw: str = output.stdout
             logger.trace(f"Raw GPG output:\n{raw}")
             return self._parse_gpg_list_cmd(raw)
@@ -252,7 +244,7 @@ class Gpg(object):
             logger.error(f"GPG command failed: {e.result.command}")
             logger.error(f"GPG stderr: {e.result.stderr}")
             logger.error(f"GPG stdout: {e.result.stdout}")
-            return []  # Return empty list on error
+            return []
         except Exception as e:
             logger.error(f"An unexpected error occurred while getting GPG keys: {e}")
             return []

--- a/secureenclave/gpg.py
+++ b/secureenclave/gpg.py
@@ -256,20 +256,49 @@ class Gpg(object):
         return final_gpg_keys
 
     def get_keys(self) -> List[GpgKey]:
-        gpg_cmd = f'{self.getbin()} --with-colons --fixed-list-mode --with-fingerprint --list-keys --list-secret-keys'
-        logger.debug(f"Executing GPG command: {gpg_cmd}")
-        try:
-            output = invoke.run(gpg_cmd, env=self.getenv(), hide=True, warn=True)
-            raw: str = output.stdout
-            logger.debug(f"Raw GPG output:\n{raw}")
-            return self._parse_gpg_list_cmd(raw)
-        except invoke.exceptions.UnexpectedExit as e:
-            logger.error(f"GPG command failed: {e.result.command}")
-            logger.error(f"GPG stderr: {e.result.stderr}")
-            logger.error(f"GPG stdout: {e.result.stdout}")
+        raw_output_parts: List[str] = []
+        base_gpg_cmd_args = [
+            self.getbin(),
+            '--with-colons',
+            '--fixed-list-mode',
+            '--with-fingerprint'
+        ]
+        common_invoke_kwargs = {'env': self.getenv(), 'hide': True, 'warn': True}
+
+        commands_to_run = [
+            (base_gpg_cmd_args + ['--list-keys'], "list-keys"),
+            (base_gpg_cmd_args + ['--list-secret-keys'], "list-secret-keys")
+        ]
+
+        for cmd_parts, desc in commands_to_run:
+            gpg_cmd_str = ' '.join(cmd_parts)
+            logger.debug(f"Executing GPG command: {gpg_cmd_str}")
+            try:
+                output = invoke.run(gpg_cmd_str, **common_invoke_kwargs)
+                if output.ok:
+                    raw_output_parts.append(output.stdout)
+                    logger.debug(f"Raw GPG output for {desc}:\n{output.stdout}")
+                else:
+                    logger.warning(f"GPG command '{gpg_cmd_str}' failed with exit code {output.return_code}.")
+                    logger.warning(f"GPG stderr for {desc}: {output.stderr}")
+            except invoke.exceptions.UnexpectedExit as e:
+                logger.error(f"GPG command '{e.result.command}' failed unexpectedly.")
+                logger.error(f"GPG stderr for {desc}: {e.result.stderr}")
+                logger.error(f"GPG stdout for {desc}: {e.result.stdout}")
+                # Depending on desired behavior, you might want to return [] here or continue
+            except Exception as e:
+                logger.error(f"An unexpected error occurred while executing GPG {desc}: {e}")
+                # Depending on desired behavior, you might want to return [] here
+
+        combined_raw_output: str = "".join(raw_output_parts)
+        if not combined_raw_output:
+            logger.debug("Combined GPG output is empty after running list-keys and list-secret-keys.")
             return []
+
+        try:
+            return self._parse_gpg_list_cmd(combined_raw_output)
         except Exception as e:
-            logger.error(f"An unexpected error occurred while getting GPG keys: {e}")
+            logger.error(f"An unexpected error occurred while parsing combined GPG key data: {e}")
             return []
 
     def card_edit(self, attribute, value):

--- a/secureenclave/gpg.py
+++ b/secureenclave/gpg.py
@@ -153,10 +153,8 @@ class Gpg(object):
                 elif is_secret_record:
                    primary_keys_info[pk_id]['secret_available'] = True
 
-                # Always update/set these fields, could be from pub then sec, or vice-versa
-                # but ensure we don't lose secret_available if pub comes after sec
                 if not is_secret_record and primary_keys_info[pk_id].get('secret_available', False):
-                    pass  # Don't overwrite secret_available = True with False from a pub record
+                    pass
                 elif is_secret_record:
                     primary_keys_info[pk_id]['secret_available'] = True
 
@@ -165,15 +163,7 @@ class Gpg(object):
                 primary_keys_info[pk_id]['creation_date'] = int(fields[5]) if fields[5].isdigit() else 0
                 primary_keys_info[pk_id]['expiration_date'] = int(fields[6]) if fields[6].isdigit() else None
                 primary_keys_info[pk_id]['owner_trust'] = GPG_OWNERTRUST_MAP.get(fields[8], "unknown") if len(fields) > 8 else "unknown"
-                # Note: 'capabilities' is cleared and re-populated a few lines below,
-                # so initializing it here might be redundant if that logic is intended to always run.
-                # However, to match the previous structure before the faulty indentation,
-                # we can keep it or remove it if the subsequent re-population is guaranteed.
-                # For now, let's assume the re-population is the primary source.
-                # primary_keys_info[pk_id]['capabilities'] = [] # This line was present before, but might be overwritten
-
                 pk_entry_ref = primary_keys_info[pk_id]
-                # Clear and re-populate capabilities, as they might differ if pub/sec records are processed sequentially for the same key
                 pk_entry_ref['capabilities'] = []
                 if len(fields) > 11 and fields[11]:
                     for char_code in fields[11]:
@@ -201,14 +191,11 @@ class Gpg(object):
                         'keygrip': None,
                         'secret_available': is_secret_subkey_record,
                     }
-                # If subkey already exists, update its secret_available status if this is a secret subkey record
                 elif is_secret_subkey_record:
                     pk_entry_ref['subkeys'][sk_id]['secret_available'] = True
 
-                # Always update/set these fields for subkeys
-                # but ensure we don't lose secret_available if sub comes after ssb
                 if not is_secret_subkey_record and pk_entry_ref['subkeys'][sk_id].get('secret_available', False):
-                    pass  # Don't overwrite secret_available = True with False
+                    pass
                 elif is_secret_subkey_record:
                     pk_entry_ref['subkeys'][sk_id]['secret_available'] = True
 
@@ -218,7 +205,6 @@ class Gpg(object):
                 pk_entry_ref['subkeys'][sk_id]['expiration_date'] = int(fields[6]) if fields[6].isdigit() else None
 
                 sk_entry_ref = pk_entry_ref['subkeys'][sk_id]
-                # Clear and re-populate capabilities for subkey
                 sk_entry_ref['capabilities'] = []
                 if len(fields) > 11 and fields[11]:
                     for char_code in fields[11]:
@@ -282,50 +268,14 @@ class Gpg(object):
         return final_gpg_keys
 
     def get_keys(self) -> List[GpgKey]:
-        raw_output_parts: List[str] = []
-        base_gpg_cmd_args = [
-            self.getbin(),
-            '--with-colons',
-            '--fixed-list-mode',
-            '--with-fingerprint'
-        ]
-        common_invoke_kwargs = {'env': self.getenv(), 'hide': True, 'warn': True}
-
-        commands_to_run = [
-            (base_gpg_cmd_args + ['--list-keys'], "list-keys"),
-            (base_gpg_cmd_args + ['--list-secret-keys'], "list-secret-keys")
-        ]
-
-        for cmd_parts, desc in commands_to_run:
-            gpg_cmd_str = ' '.join(cmd_parts)
-            logger.debug(f"Executing GPG command: {gpg_cmd_str}")
-            try:
-                output = invoke.run(gpg_cmd_str, **common_invoke_kwargs)
-                if output.ok:
-                    raw_output_parts.append(output.stdout)
-                    logger.debug(f"Raw GPG output for {desc}:\n{output.stdout}")
-                else:
-                    logger.warning(f"GPG command '{gpg_cmd_str}' failed with exit code {output.return_code}.")
-                    logger.warning(f"GPG stderr for {desc}: {output.stderr}")
-            except invoke.exceptions.UnexpectedExit as e:
-                logger.error(f"GPG command '{e.result.command}' failed unexpectedly.")
-                logger.error(f"GPG stderr for {desc}: {e.result.stderr}")
-                logger.error(f"GPG stdout for {desc}: {e.result.stdout}")
-                # Depending on desired behavior, you might want to return [] here or continue
-            except Exception as e:
-                logger.error(f"An unexpected error occurred while executing GPG {desc}: {e}")
-                # Depending on desired behavior, you might want to return [] here
-
-        combined_raw_output: str = "".join(raw_output_parts)
-        if not combined_raw_output:
-            logger.debug("Combined GPG output is empty after running list-keys and list-secret-keys.")
-            return []
-
-        try:
-            return self._parse_gpg_list_cmd(combined_raw_output)
-        except Exception as e:
-            logger.error(f"An unexpected error occurred while parsing combined GPG key data: {e}")
-            return []
+        command = f'{self.getbin()} --with-colons --fixed-list-mode --with-fingerprint --list-keys'
+        output = invoke.run(command=command, env=self.getenv(), hide=True, warn=True)
+        public_keys = self._parse_gpg_list_cmd(output.raw_output)
+        command = f'{self.getbin()} --with-colons --fixed-list-mode --with-fingerprint --list-secret-keys'
+        output = invoke.run(command=command, env=self.getenv(), hide=True, warn=True)
+        secret_keys = self._parse_gpg_list_cmd(output.raw_output)
+        keys = self._dedup_keys(public_keys, secret_keys)
+        return keys
 
     def card_edit(self, attribute, value):
         __content__ = __gpg_card_edit__.format(attribute, value)

--- a/secureenclave/gpg.py
+++ b/secureenclave/gpg.py
@@ -160,7 +160,6 @@ class Gpg(object):
                 elif is_secret_record:
                     primary_keys_info[pk_id]['secret_available'] = True
 
-
                 primary_keys_info[pk_id]['algorithm_name'] = GPG_ALGORITHM_NAME_MAP.get(fields[3], f"unknown_algo_{fields[3]}")
                 primary_keys_info[pk_id]['key_length'] = int(fields[2]) if fields[2].isdigit() else 0
                 primary_keys_info[pk_id]['creation_date'] = int(fields[5]) if fields[5].isdigit() else 0

--- a/secureenclave/gpg.py
+++ b/secureenclave/gpg.py
@@ -15,7 +15,7 @@ import urllib.parse
 from loguru import logger
 from typing import List, Dict, Any
 
-from secureenclave.datamodel import GpgKey
+from secureenclave.datamodel import GpgKey, GpgSubkey
 
 
 __gpg_conf__: str = """use-agent
@@ -118,17 +118,20 @@ class Gpg(object):
         return self.gpg_bin
 
     def _parse_gpg_list_cmd(self, raw_output: str) -> List[GpgKey]:
-        keys_list: List[GpgKey] = []
-        current_key_details: Dict[str, Any] = {}
+        parsed_keys: List[GpgKey] = []
+        current_primary_key_data: Optional[Dict[str, Any]] = None
+        # attachment_target points to the dict (primary or subkey) that should receive next fpr/grp
+        attachment_target: Optional[Dict[str, Any]] = None
 
         for line in raw_output.splitlines():
             fields = line.strip().split(':')
-            if not fields:
+            if not fields or len(fields) < 1:
                 continue
 
             record_type = fields[0]
+
             if record_type == 'pub':
-                current_key_details = {
+                current_primary_key_data = {
                     'key_id': fields[4],
                     'algorithm_name': GPG_ALGORITHM_NAME_MAP.get(fields[3], f"unknown_algo_{fields[3]}"),
                     'key_length': int(fields[2]) if fields[2].isdigit() else 0,
@@ -138,69 +141,100 @@ class Gpg(object):
                     'capabilities': [],
                     'fingerprint': None,
                     'keygrip': None,
+                    'subkeys': [],  # Stores raw subkey dictionaries
                 }
+                attachment_target = current_primary_key_data
                 # Parse capabilities from field 11 (e.g., "scea")
                 if len(fields) > 11 and fields[11]:
                     for char_code in fields[11]:
-                        current_key_details['capabilities'].append(GPG_CAPABILITY_MAP.get(char_code, f"unknown_cap_{char_code}"))
-                logger.debug(f"Parsing pub key: {current_key_details['key_id']}")
+                        current_primary_key_data['capabilities'].append(GPG_CAPABILITY_MAP.get(char_code, f"unknown_cap_{char_code}"))
+                logger.debug(f"Parsing pub key: {current_primary_key_data['key_id']}")
 
-            elif record_type == 'fpr' and current_key_details:
-                if len(fields) > 9:
-                    current_key_details['fingerprint'] = fields[9]
-                    logger.debug(f"Found fingerprint for {current_key_details.get('key_id')}: {fields[9]}")
+            elif record_type in ('sub', 'ssb'):
+                if not current_primary_key_data:
+                    logger.warning(f"Orphaned subkey record found: {line}. Skipping.")
+                    continue
+                
+                subkey_caps = []
+                if len(fields) > 11 and fields[11]:
+                    for char_code in fields[11]:
+                        subkey_caps.append(GPG_CAPABILITY_MAP.get(char_code, f"unknown_cap_{char_code}"))
 
-            elif record_type == 'grp' and current_key_details:
-                if len(fields) > 9:
-                    current_key_details['keygrip'] = fields[9]
-                    logger.debug(f"Found keygrip for {current_key_details.get('key_id')}: {fields[9]}")
+                current_subkey_dict = {
+                    'key_id': fields[4],
+                    'algorithm_name': GPG_ALGORITHM_NAME_MAP.get(fields[3], f"unknown_algo_{fields[3]}"),
+                    'key_length': int(fields[2]) if fields[2].isdigit() else 0,
+                    'creation_date': int(fields[5]) if fields[5].isdigit() else 0,
+                    'expiration_date': int(fields[6]) if fields[6].isdigit() else None,
+                    'capabilities': subkey_caps,
+                    'fingerprint': None,
+                    'keygrip': None,
+                }
+                current_primary_key_data['subkeys'].append(current_subkey_dict)
+                attachment_target = current_subkey_dict
+                logger.debug(f"Parsing subkey: {current_subkey_dict['key_id']} for pub {current_primary_key_data['key_id']}")
 
-            elif record_type == 'uid' and current_key_details and 'key_id' in current_key_details:
-                uid_string = ""
-                if len(fields) > 9:  # GnuPG 2.1+ format
-                    uid_string = urllib.parse.unquote_plus(fields[9])
-                elif len(fields) > 7:  # Older GnuPG format might have UID in field 7
-                    uid_string = urllib.parse.unquote_plus(fields[7])
+            elif record_type == 'fpr':
+                if attachment_target and len(fields) > 9:
+                    fingerprint_val = fields[9]
+                    attachment_target['fingerprint'] = fingerprint_val
+                    logger.debug(f"Found fingerprint for {attachment_target.get('key_id')}: {fingerprint_val}")
+                else:
+                    logger.warning(f"Orphaned fingerprint record or missing target: {line}")
+            
+            elif record_type == 'grp':
+                if attachment_target and len(fields) > 9:
+                    keygrip_val = fields[9]
+                    attachment_target['keygrip'] = keygrip_val
+                    logger.debug(f"Found keygrip for {attachment_target.get('key_id')}: {keygrip_val}")
+                else:
+                    logger.warning(f"Orphaned keygrip record or missing target: {line}")
 
+            elif record_type == 'uid':
+                if not current_primary_key_data:
+                    logger.warning(f"Orphaned UID record found: {line}. Skipping.")
+                    continue
+
+                uid_string = urllib.parse.unquote_plus(fields[9]) if len(fields) > 9 else ""
                 uid_validity_char = fields[1]
                 uid_validity = GPG_VALIDITY_MAP.get(uid_validity_char, "unknown validity")
 
                 if not uid_string:
-                    logger.warning(f"Skipping UID for key {current_key_details['key_id']} due to empty UID string. Line: {line}")
+                    logger.warning(f"Skipping UID for key {current_primary_key_data['key_id']} due to empty UID string. Line: {line}")
                     continue
+
+                # Convert raw subkey dicts to GpgSubkey objects
+                subkeys_list = []
+                for sub_dict in current_primary_key_data.get('subkeys', []):
+                    subkeys_list.append(GpgSubkey(**sub_dict))
 
                 gpg_key = GpgKey(
                     uid=uid_string,
-                    key_id=current_key_details['key_id'],
-                    fingerprint=current_key_details.get('fingerprint'),
+                    key_id=current_primary_key_data['key_id'],
+                    fingerprint=current_primary_key_data.get('fingerprint'),
                     uid_validity=uid_validity,
-                    owner_trust=current_key_details.get('owner_trust'),
-                    algorithm_name=current_key_details['algorithm_name'],
-                    key_length=current_key_details['key_length'],
-                    creation_date=current_key_details['creation_date'],
-                    expiration_date=current_key_details.get('expiration_date'),
-                    capabilities=current_key_details.get('capabilities', []),
-                    keygrip=current_key_details.get('keygrip')
+                    owner_trust=current_primary_key_data.get('owner_trust'),
+                    algorithm_name=current_primary_key_data['algorithm_name'],
+                    key_length=current_primary_key_data['key_length'],
+                    creation_date=current_primary_key_data['creation_date'],
+                    expiration_date=current_primary_key_data.get('expiration_date'),
+                    capabilities=current_primary_key_data.get('capabilities', []),
+                    keygrip=current_primary_key_data.get('keygrip'),
+                    subkeys=subkeys_list
                 )
-                keys_list.append(gpg_key)
-                logger.debug(f"Added GpgKey: {uid_string} for key {current_key_details['key_id']}")
+                parsed_keys.append(gpg_key)
+                logger.debug(f"Added GpgKey: {uid_string} for key {current_primary_key_data['key_id']} with {len(subkeys_list)} subkeys")
+                # After a UID, subsequent fpr/grp should ideally target the primary key again
+                # if they appear before a new 'sub' or 'pub'.
+                attachment_target = current_primary_key_data
 
-            elif record_type in ('sub', 'ssb'):  # Subkey, reset current_key_details to avoid associating UIDs with subkeys
-                # For now, we are not parsing subkeys into GpgKey objects in this list.
-                # If subkeys were to be listed, they'd need their own 'fpr', 'grp' etc.
-                # Resetting current_key_details ensures subsequent UIDs are not wrongly associated.
-                # However, GPG lists UIDs under their primary key, not subkeys.
-                # So, this might not be strictly necessary unless the output format changes.
-                # For safety, we can clear parts that are subkey-specific if we were to process them.
-                # For now, we assume UIDs always belong to the last 'pub' key.
-                pass
 
-        if not keys_list and raw_output:
+        if not parsed_keys and raw_output:
             logger.debug("No keys found or parsed from GPG output.")
         elif not raw_output:
             logger.debug("GPG output was empty.")
 
-        return keys_list
+        return parsed_keys
 
     def get_keys(self) -> List[GpgKey]:
         # Use --with-colons for machine-readable output

--- a/secureenclave/gpg.py
+++ b/secureenclave/gpg.py
@@ -13,7 +13,7 @@ from io import StringIO
 import urllib.parse
 
 from loguru import logger
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 from secureenclave.datamodel import GpgKey, GpgSubkey
 
@@ -65,7 +65,7 @@ GPG_VALIDITY_MAP: Dict[str, str] = {
     'f': "fully valid",
     'u': "ultimately valid",
     's': "special validity",
-    'w': "well-known public key", 
+    'w': "well-known public key",
 }
 
 GPG_OWNERTRUST_MAP: Dict[str, str] = {
@@ -154,7 +154,7 @@ class Gpg(object):
                 if not current_primary_key_data:
                     logger.warning(f"Orphaned subkey record found: {line}. Skipping.")
                     continue
-                
+
                 subkey_caps = []
                 if len(fields) > 11 and fields[11]:
                     for char_code in fields[11]:
@@ -181,7 +181,7 @@ class Gpg(object):
                     logger.debug(f"Found fingerprint for {attachment_target.get('key_id')}: {fingerprint_val}")
                 else:
                     logger.warning(f"Orphaned fingerprint record or missing target: {line}")
-            
+
             elif record_type == 'grp':
                 if attachment_target and len(fields) > 9:
                     keygrip_val = fields[9]
@@ -227,7 +227,6 @@ class Gpg(object):
                 # After a UID, subsequent fpr/grp should ideally target the primary key again
                 # if they appear before a new 'sub' or 'pub'.
                 attachment_target = current_primary_key_data
-
 
         if not parsed_keys and raw_output:
             logger.debug("No keys found or parsed from GPG output.")

--- a/secureenclave/gpg.py
+++ b/secureenclave/gpg.py
@@ -147,18 +147,15 @@ class Gpg(object):
                         'keygrip': None,
                         'is_secret': is_secret_record,
                         'uids': [],
-                        'subkeys': {},  # Stores subkey data dicts, keyed by subkey_id
+                        'subkeys': {},
                     }
                 else:
-                    # Update existing entry, especially is_secret
                     primary_keys_info[pk_id]['is_secret'] = primary_keys_info[pk_id]['is_secret'] or is_secret_record
-                    # Re-parse fields that might differ or be more complete in a 'sec' record (though usually not)
                     primary_keys_info[pk_id]['algorithm_name'] = GPG_ALGORITHM_NAME_MAP.get(fields[3], f"unknown_algo_{fields[3]}")
                     primary_keys_info[pk_id]['key_length'] = int(fields[2]) if fields[2].isdigit() else 0
                     primary_keys_info[pk_id]['creation_date'] = int(fields[5]) if fields[5].isdigit() else 0
                     primary_keys_info[pk_id]['expiration_date'] = int(fields[6]) if fields[6].isdigit() else None
                     primary_keys_info[pk_id]['owner_trust'] = GPG_OWNERTRUST_MAP.get(fields[8], "unknown") if len(fields) > 8 else "unknown"
-                    # Capabilities might be additive or different, clear and re-add for simplicity
                     primary_keys_info[pk_id]['capabilities'] = []
 
                 pk_entry_ref = primary_keys_info[pk_id]
@@ -190,7 +187,6 @@ class Gpg(object):
                     }
                 else:
                     pk_entry_ref['subkeys'][sk_id]['is_secret'] = pk_entry_ref['subkeys'][sk_id]['is_secret'] or is_secret_subkey_record
-                    # Re-parse fields for subkey
                     pk_entry_ref['subkeys'][sk_id]['algorithm_name'] = GPG_ALGORITHM_NAME_MAP.get(fields[3], f"unknown_algo_{fields[3]}")
                     pk_entry_ref['subkeys'][sk_id]['key_length'] = int(fields[2]) if fields[2].isdigit() else 0
                     pk_entry_ref['subkeys'][sk_id]['creation_date'] = int(fields[5]) if fields[5].isdigit() else 0
@@ -198,7 +194,7 @@ class Gpg(object):
                     pk_entry_ref['subkeys'][sk_id]['capabilities'] = []
 
                 sk_entry_ref = pk_entry_ref['subkeys'][sk_id]
-                if len(fields) > 11 and fields[11]:  # Subkey capabilities
+                if len(fields) > 11 and fields[11]:
                     for char_code in fields[11]:
                         sk_entry_ref['capabilities'].append(GPG_CAPABILITY_MAP.get(char_code, f"unknown_cap_{char_code}"))
                 attachment_target_dict = sk_entry_ref
@@ -234,20 +230,17 @@ class Gpg(object):
                     'uid_text': uid_string,
                     'uid_validity': uid_validity,
                 })
-                attachment_target_dict = primary_keys_info[current_pk_id_active]  # Reset target to primary key
+                attachment_target_dict = primary_keys_info[current_pk_id_active]
                 logger.debug(f"Processed UID: '{uid_string}' for pk {current_pk_id_active}")
 
-        # Construct final GpgKey objects
         final_gpg_keys: List[GpgKey] = []
         for pk_id, pk_data_dict in primary_keys_info.items():
             subkeys_obj_list: List[GpgSubkey] = []
             for sk_id, sk_data_dict in pk_data_dict.get('subkeys', {}).items():
                 subkeys_obj_list.append(GpgSubkey(**sk_data_dict))
-            # Create a GpgKey object for each UID associated with this primary key
             if not pk_data_dict.get('uids'):
                 logger.warning(f"Primary key {pk_id} has no UIDs. Skipping GpgKey object creation for it directly, though its subkeys are parsed.")
             for uid_info in pk_data_dict.get('uids', []):
-                # Prepare pk_data_dict for GpgKey constructor by removing non-GpgKey fields
                 constructor_pk_data = {k: v for k, v in pk_data_dict.items() if k not in ['uids', 'subkeys']}
                 gpg_key_obj = GpgKey(
                     uid=uid_info['uid_text'],
@@ -267,9 +260,8 @@ class Gpg(object):
         logger.debug(f"Executing GPG command: {gpg_cmd}")
         try:
             output = invoke.run(gpg_cmd, env=self.getenv(), hide=True, warn=True)
-            output.raise_for_status()
             raw: str = output.stdout
-            logger.trace(f"Raw GPG output:\n{raw}")
+            logger.debug(f"Raw GPG output:\n{raw}")
             return self._parse_gpg_list_cmd(raw)
         except invoke.exceptions.UnexpectedExit as e:
             logger.error(f"GPG command failed: {e.result.command}")

--- a/secureenclave/gpg.py
+++ b/secureenclave/gpg.py
@@ -151,14 +151,14 @@ class Gpg(object):
                     }
                 # If key already exists, update its secret_available status if this is a secret key record
                 elif is_secret_record:
-                    primary_keys_info[pk_id]['secret_available'] = True
-                
+                   primary_keys_info[pk_id]['secret_available'] = True
+
                 # Always update/set these fields, could be from pub then sec, or vice-versa
                 # but ensure we don't lose secret_available if pub comes after sec
                 if not is_secret_record and primary_keys_info[pk_id].get('secret_available', False):
-                    pass # Don't overwrite secret_available = True with False from a pub record
+                    pass  # Don't overwrite secret_available = True with False from a pub record
                 elif is_secret_record:
-                     primary_keys_info[pk_id]['secret_available'] = True
+                    primary_keys_info[pk_id]['secret_available'] = True
 
 
                 primary_keys_info[pk_id]['algorithm_name'] = GPG_ALGORITHM_NAME_MAP.get(fields[3], f"unknown_algo_{fields[3]}")
@@ -209,7 +209,7 @@ class Gpg(object):
                 # Always update/set these fields for subkeys
                 # but ensure we don't lose secret_available if sub comes after ssb
                 if not is_secret_subkey_record and pk_entry_ref['subkeys'][sk_id].get('secret_available', False):
-                    pass # Don't overwrite secret_available = True with False
+                    pass  # Don't overwrite secret_available = True with False
                 elif is_secret_subkey_record:
                     pk_entry_ref['subkeys'][sk_id]['secret_available'] = True
 
@@ -217,7 +217,7 @@ class Gpg(object):
                 pk_entry_ref['subkeys'][sk_id]['key_length'] = int(fields[2]) if fields[2].isdigit() else 0
                 pk_entry_ref['subkeys'][sk_id]['creation_date'] = int(fields[5]) if fields[5].isdigit() else 0
                 pk_entry_ref['subkeys'][sk_id]['expiration_date'] = int(fields[6]) if fields[6].isdigit() else None
-                
+
                 sk_entry_ref = pk_entry_ref['subkeys'][sk_id]
                 # Clear and re-populate capabilities for subkey
                 sk_entry_ref['capabilities'] = []

--- a/secureenclave/gpg.py
+++ b/secureenclave/gpg.py
@@ -149,7 +149,6 @@ class Gpg(object):
                         'uids': [],
                         'subkeys': {},
                     }
-                # If key already exists, update its secret_available status if this is a secret key record
                 elif is_secret_record:
                     primary_keys_info[pk_id]['secret_available'] = True
 
@@ -276,47 +275,35 @@ class Gpg(object):
         """
         merged_keys_map: Dict[Tuple[str, str], GpgKey] = {}
 
-        # First, add all public keys. Their secret_available flags are False by default
-        # as parsed by _parse_gpg_list_cmd when called with --list-keys output.
         for pub_key in public_keys:
             key_tuple = (pub_key.key_id, pub_key.uid)
             merged_keys_map[key_tuple] = pub_key
 
-        # Now, process secret keys.
-        # If a key exists from public_keys, update its secret_available status.
-        # If it doesn't exist, add the secret key (all its flags are already True).
         for sec_key in secret_keys:
             key_tuple = (sec_key.key_id, sec_key.uid)
             if key_tuple in merged_keys_map:
-                # Key already exists from public_keys list. Update its secret_available flags.
                 existing_key = merged_keys_map[key_tuple]
-                existing_key.secret_available = True  # sec_key has this True
-
-                # Create a map of existing subkeys for quick lookup and update
+                existing_key.secret_available = True
                 existing_subkeys_map: Dict[str, GpgSubkey] = {
                     subkey.key_id: subkey for subkey in existing_key.subkeys
                 }
 
                 for sec_subkey in sec_key.subkeys:
                     if sec_subkey.key_id in existing_subkeys_map:
-                        # Subkey exists, update its secret_available flag
-                        # sec_subkey from secret_keys list has secret_available=True
                         existing_subkeys_map[sec_subkey.key_id].secret_available = True
                     else:
-                        # This secret subkey was not in the public key's subkey list. Add it.
-                        # Its secret_available is already True from parsing secret_keys.
                         existing_key.subkeys.append(sec_subkey)
             else:
-                # This secret key (and its subkeys) was not in public_keys list. Add it directly.
-                # All its secret_available flags are already True.
                 merged_keys_map[key_tuple] = sec_key
 
         return list(merged_keys_map.values())
 
     def get_keys(self) -> List[GpgKey]:
+        logger.info('Getting the public keys')
         command = f'{self.getbin()} --with-colons --fixed-list-mode --with-fingerprint --list-keys'
         output = invoke.run(command=command, env=self.getenv(), hide=True, warn=True)
         public_keys = self._parse_gpg_list_cmd(output.stdout)
+        logger.info('Retrieving the secret keys')
         command = f'{self.getbin()} --with-colons --fixed-list-mode --with-fingerprint --list-secret-keys'
         output = invoke.run(command=command, env=self.getenv(), hide=True, warn=True)
         secret_keys = self._parse_gpg_list_cmd(output.stdout)

--- a/secureenclave/gpg.py
+++ b/secureenclave/gpg.py
@@ -145,25 +145,37 @@ class Gpg(object):
                         'capabilities': [],
                         'fingerprint': None,
                         'keygrip': None,
-                        'is_secret': is_secret_record,
+                        'secret_available': is_secret_record,
                         'uids': [],
                         'subkeys': {},
                     }
-                else:
-                    primary_keys_info[pk_id]['is_secret'] = primary_keys_info[pk_id]['is_secret'] or is_secret_record
-                    primary_keys_info[pk_id]['algorithm_name'] = GPG_ALGORITHM_NAME_MAP.get(fields[3], f"unknown_algo_{fields[3]}")
-                    primary_keys_info[pk_id]['key_length'] = int(fields[2]) if fields[2].isdigit() else 0
-                    primary_keys_info[pk_id]['creation_date'] = int(fields[5]) if fields[5].isdigit() else 0
+                # If key already exists, update its secret_available status if this is a secret key record
+                elif is_secret_record:
+                    primary_keys_info[pk_id]['secret_available'] = True
+                
+                # Always update/set these fields, could be from pub then sec, or vice-versa
+                # but ensure we don't lose secret_available if pub comes after sec
+                if not is_secret_record and primary_keys_info[pk_id].get('secret_available', False):
+                    pass # Don't overwrite secret_available = True with False from a pub record
+                elif is_secret_record:
+                     primary_keys_info[pk_id]['secret_available'] = True
+
+
+                primary_keys_info[pk_id]['algorithm_name'] = GPG_ALGORITHM_NAME_MAP.get(fields[3], f"unknown_algo_{fields[3]}")
+                primary_keys_info[pk_id]['key_length'] = int(fields[2]) if fields[2].isdigit() else 0
+                primary_keys_info[pk_id]['creation_date'] = int(fields[5]) if fields[5].isdigit() else 0
                     primary_keys_info[pk_id]['expiration_date'] = int(fields[6]) if fields[6].isdigit() else None
                     primary_keys_info[pk_id]['owner_trust'] = GPG_OWNERTRUST_MAP.get(fields[8], "unknown") if len(fields) > 8 else "unknown"
                     primary_keys_info[pk_id]['capabilities'] = []
 
                 pk_entry_ref = primary_keys_info[pk_id]
+                # Clear and re-populate capabilities, as they might differ if pub/sec records are processed sequentially for the same key
+                pk_entry_ref['capabilities'] = []
                 if len(fields) > 11 and fields[11]:
                     for char_code in fields[11]:
                         pk_entry_ref['capabilities'].append(GPG_CAPABILITY_MAP.get(char_code, f"unknown_cap_{char_code}"))
                 attachment_target_dict = pk_entry_ref
-                logger.debug(f"Processed {record_type} key: {pk_id}, is_secret: {pk_entry_ref['is_secret']}")
+                logger.debug(f"Processed {record_type} key: {pk_id}, secret_available: {pk_entry_ref['secret_available']}")
 
             elif record_type in ('sub', 'ssb'):
                 if not current_pk_id_active:
@@ -183,22 +195,32 @@ class Gpg(object):
                         'capabilities': [],
                         'fingerprint': None,
                         'keygrip': None,
-                        'is_secret': is_secret_subkey_record,
+                        'secret_available': is_secret_subkey_record,
                     }
-                else:
-                    pk_entry_ref['subkeys'][sk_id]['is_secret'] = pk_entry_ref['subkeys'][sk_id]['is_secret'] or is_secret_subkey_record
-                    pk_entry_ref['subkeys'][sk_id]['algorithm_name'] = GPG_ALGORITHM_NAME_MAP.get(fields[3], f"unknown_algo_{fields[3]}")
-                    pk_entry_ref['subkeys'][sk_id]['key_length'] = int(fields[2]) if fields[2].isdigit() else 0
-                    pk_entry_ref['subkeys'][sk_id]['creation_date'] = int(fields[5]) if fields[5].isdigit() else 0
-                    pk_entry_ref['subkeys'][sk_id]['expiration_date'] = int(fields[6]) if fields[6].isdigit() else None
-                    pk_entry_ref['subkeys'][sk_id]['capabilities'] = []
+                # If subkey already exists, update its secret_available status if this is a secret subkey record
+                elif is_secret_subkey_record:
+                    pk_entry_ref['subkeys'][sk_id]['secret_available'] = True
 
+                # Always update/set these fields for subkeys
+                # but ensure we don't lose secret_available if sub comes after ssb
+                if not is_secret_subkey_record and pk_entry_ref['subkeys'][sk_id].get('secret_available', False):
+                    pass # Don't overwrite secret_available = True with False
+                elif is_secret_subkey_record:
+                    pk_entry_ref['subkeys'][sk_id]['secret_available'] = True
+
+                pk_entry_ref['subkeys'][sk_id]['algorithm_name'] = GPG_ALGORITHM_NAME_MAP.get(fields[3], f"unknown_algo_{fields[3]}")
+                pk_entry_ref['subkeys'][sk_id]['key_length'] = int(fields[2]) if fields[2].isdigit() else 0
+                pk_entry_ref['subkeys'][sk_id]['creation_date'] = int(fields[5]) if fields[5].isdigit() else 0
+                pk_entry_ref['subkeys'][sk_id]['expiration_date'] = int(fields[6]) if fields[6].isdigit() else None
+                
                 sk_entry_ref = pk_entry_ref['subkeys'][sk_id]
+                # Clear and re-populate capabilities for subkey
+                sk_entry_ref['capabilities'] = []
                 if len(fields) > 11 and fields[11]:
                     for char_code in fields[11]:
                         sk_entry_ref['capabilities'].append(GPG_CAPABILITY_MAP.get(char_code, f"unknown_cap_{char_code}"))
                 attachment_target_dict = sk_entry_ref
-                logger.debug(f"Processed {record_type} subkey: {sk_id} for pk {current_pk_id_active}, is_secret: {sk_entry_ref['is_secret']}")
+                logger.debug(f"Processed {record_type} subkey: {sk_id} for pk {current_pk_id_active}, secret_available: {sk_entry_ref['secret_available']}")
 
             elif record_type == 'fpr':
                 if attachment_target_dict and len(fields) > 9:

--- a/secureenclave/gpg.py
+++ b/secureenclave/gpg.py
@@ -11,9 +11,10 @@ import shutil
 import invoke
 import re
 from io import StringIO
+import urllib.parse
 
 from loguru import logger
-from typing import List
+from typing import List, Dict, Any, Optional
 
 from secureenclave.datamodel import GpgKey
 
@@ -47,6 +48,50 @@ keytocard
 save
 """
 
+# Mappings for GPG --with-colons output
+GPG_ALGORITHM_NAME_MAP: Dict[str, str] = {
+    "1": "RSA", "2": "RSA-E", "3": "RSA-S", "16": "ELG-E", "17": "DSA",
+    "18": "ECC", "19": "ECDSA", "20": "ELG", "21": "PAD", "22": "EDDSA",
+    # Add others as needed
+}
+
+GPG_VALIDITY_MAP: Dict[str, str] = {
+    'o': "unknown validity",
+    'i': "invalid",
+    'd': "disabled",
+    'r': "revoked",
+    'e': "expired",
+    '-': "validity not indicated",
+    'q': "undefined validity",
+    'n': "not valid",
+    'm': "marginally valid",
+    'f': "fully valid",
+    'u': "ultimately valid",
+    's': "special validity",
+    'w': "well-known public key", # GnuPG specific
+}
+
+GPG_OWNERTRUST_MAP: Dict[str, str] = {
+    '-': "unknown",
+    'o': "unknown", # GnuPG specific for "not enough information"
+    'q': "undefined",
+    'n': "not trusted",
+    'm': "marginally trusted",
+    'f': "fully trusted",
+    'u': "ultimately trusted",
+    'e': "expired", # GnuPG specific for expired trust signature
+    'r': "revoked", # GnuPG specific for revoked trust signature
+}
+
+GPG_CAPABILITY_MAP: Dict[str, str] = {
+    'e': "encrypt",
+    's': "sign",
+    'c': "certify",
+    'a': "authenticate",
+    't': "set-primary-uid", # GnuPG specific, often on self-signatures
+    '?': "unknown"
+}
+
 
 class Gpg(object):
     def __init__(self, homepath):
@@ -76,31 +121,120 @@ class Gpg(object):
         return self.gpg_bin
 
     def _parse_gpg_list_cmd(self, raw_output: str) -> List[GpgKey]:
-        keys: List[GpgKey] = []
-        if 'uid  ' in raw_output:
-            logger.debug('There is at least a uid in the keylist')
-            uid = fingerprint = pub = trust = None
-            for line in raw_output.splitlines():
-                if match := re.search('fingerprint[ ]*= ([A-F0-9 ]*)', line):
-                    fingerprint = match.group(1).replace(" ", "")
-                if match := re.search('uid (.*)$', line):
-                    uid = match.group(1).strip()
-                    if submatch := re.search("(\\[[ a-z]*\\]) (.*)", uid):
-                        uid = submatch.group(2).strip()
-                        trust = submatch.group(1).replace("[", "").replace("]", "").strip()
-                if match := re.search('pub [ ]*([a-zA-Z0-9\\/]*)', line):
-                    pub = match.group(1)
-                if pub and fingerprint and uid and trust:
-                    logger.debug(f'Found a full match key uuid {uid} - {pub}')
-                    keys.append(GpgKey(uid, pub, fingerprint, trust))
-                    pub = fingerprint = uid = trust = None
-        return keys
+        keys_list: List[GpgKey] = []
+        current_key_details: Dict[str, Any] = {}
 
-    def get_keys(self):
-        gpg_cmd = '{} --quiet --list-keys'.format(self.getbin())
-        output = invoke.run(gpg_cmd, env=self.getenv(), pty=True, hide=True)
-        raw = output.stdout  # type: ignore
-        return self._parse_gpg_list_cmd(raw)
+        for line in raw_output.splitlines():
+            fields = line.strip().split(':')
+            if not fields:
+                continue
+
+            record_type = fields[0]
+
+            if record_type == 'pub':
+                # Start of a new public key block
+                current_key_details = {
+                    'key_id': fields[4],
+                    'algorithm_name': GPG_ALGORITHM_NAME_MAP.get(fields[3], f"unknown_algo_{fields[3]}"),
+                    'key_length': int(fields[2]) if fields[2].isdigit() else 0,
+                    'creation_date': int(fields[5]) if fields[5].isdigit() else 0,
+                    'expiration_date': int(fields[6]) if fields[6].isdigit() else None,
+                    'owner_trust': GPG_OWNERTRUST_MAP.get(fields[8], "unknown") if len(fields) > 8 else "unknown",
+                    'capabilities': [],
+                    'fingerprint': None, # Will be filled by 'fpr' record
+                    'keygrip': None,     # Will be filled by 'grp' record
+                }
+                # Parse capabilities from field 11 (e.g., "scea")
+                if len(fields) > 11 and fields[11]:
+                    for char_code in fields[11]:
+                        current_key_details['capabilities'].append(GPG_CAPABILITY_MAP.get(char_code, f"unknown_cap_{char_code}"))
+                logger.debug(f"Parsing pub key: {current_key_details['key_id']}")
+
+            elif record_type == 'fpr' and current_key_details:
+                # Fingerprint for the current key
+                if len(fields) > 9:
+                    current_key_details['fingerprint'] = fields[9]
+                    logger.debug(f"Found fingerprint for {current_key_details.get('key_id')}: {fields[9]}")
+
+
+            elif record_type == 'grp' and current_key_details:
+                # Keygrip for the current key
+                if len(fields) > 9:
+                    current_key_details['keygrip'] = fields[9]
+                    logger.debug(f"Found keygrip for {current_key_details.get('key_id')}: {fields[9]}")
+
+            elif record_type == 'uid' and current_key_details and 'key_id' in current_key_details:
+                # User ID for the current key
+                uid_string = ""
+                if len(fields) > 9: # GnuPG 2.1+ format
+                    uid_string = urllib.parse.unquote_plus(fields[9])
+                elif len(fields) > 7: # Older GnuPG format might have UID in field 7
+                     uid_string = urllib.parse.unquote_plus(fields[7])
+
+
+                uid_validity_char = fields[1]
+                uid_validity = GPG_VALIDITY_MAP.get(uid_validity_char, "unknown validity")
+
+                if not uid_string: # Skip if UID string is empty
+                    logger.warning(f"Skipping UID for key {current_key_details['key_id']} due to empty UID string. Line: {line}")
+                    continue
+
+                gpg_key = GpgKey(
+                    uid=uid_string,
+                    key_id=current_key_details['key_id'],
+                    fingerprint=current_key_details.get('fingerprint'),
+                    uid_validity=uid_validity,
+                    owner_trust=current_key_details.get('owner_trust'),
+                    algorithm_name=current_key_details['algorithm_name'],
+                    key_length=current_key_details['key_length'],
+                    creation_date=current_key_details['creation_date'],
+                    expiration_date=current_key_details.get('expiration_date'),
+                    capabilities=current_key_details.get('capabilities', []),
+                    keygrip=current_key_details.get('keygrip')
+                )
+                keys_list.append(gpg_key)
+                logger.debug(f"Added GpgKey: {uid_string} for key {current_key_details['key_id']}")
+
+            elif record_type in ('sub', 'ssb'): # Subkey, reset current_key_details to avoid associating UIDs with subkeys
+                # For now, we are not parsing subkeys into GpgKey objects in this list.
+                # If subkeys were to be listed, they'd need their own 'fpr', 'grp' etc.
+                # Resetting current_key_details ensures subsequent UIDs are not wrongly associated.
+                # However, GPG lists UIDs under their primary key, not subkeys.
+                # So, this might not be strictly necessary unless the output format changes.
+                # For safety, we can clear parts that are subkey-specific if we were to process them.
+                # For now, we assume UIDs always belong to the last 'pub' key.
+                pass
+
+
+        if not keys_list and raw_output:
+            logger.debug("No keys found or parsed from GPG output.")
+        elif not raw_output:
+            logger.debug("GPG output was empty.")
+
+        return keys_list
+
+    def get_keys(self) -> List[GpgKey]:
+        # Use --with-colons for machine-readable output
+        # --fixed-list-mode helps stabilize output across GPG versions
+        # --with-fingerprint ensures fingerprints are included
+        gpg_cmd = f'{self.getbin()} --with-colons --fixed-list-mode --with-fingerprint --list-keys'
+        logger.debug(f"Executing GPG command: {gpg_cmd}")
+        try:
+            # pty=True is generally not recommended for machine-readable output
+            output = invoke.run(gpg_cmd, env=self.getenv(), hide=True, warn=True) # warn=True to catch errors
+            output.raise_for_status() # Raise HTTPError for bad responses (4xx or 5xx)
+            raw: str = output.stdout
+            logger.trace(f"Raw GPG output:\n{raw}")
+            return self._parse_gpg_list_cmd(raw)
+        except invoke.exceptions.UnexpectedExit as e:
+            logger.error(f"GPG command failed: {e.result.command}")
+            logger.error(f"GPG stderr: {e.result.stderr}")
+            logger.error(f"GPG stdout: {e.result.stdout}")
+            return [] # Return empty list on error
+        except Exception as e:
+            logger.error(f"An unexpected error occurred while getting GPG keys: {e}")
+            return []
+
 
     def card_edit(self, attribute, value):
         __content__ = __gpg_card_edit__.format(attribute, value)

--- a/secureenclave/secureenclave.py
+++ b/secureenclave/secureenclave.py
@@ -278,24 +278,23 @@ class SecureEnclave(object):
         logger.info(f"Attempting to delete secret key for {selected.fingerprint}...")
         gpg_cmd_secret = '{} -q --batch --delete-secret-key {}'.format(self.gpg.getbin(), selected.fingerprint)
         result_secret = invoke.run(gpg_cmd_secret, env=self.gpg.getenv(), pty=True, hide=True)
-        if result_secret.ok: # type: ignore
+        if result_secret.ok:  # type: ignore
             logger.success(f"Secret key for {selected.fingerprint} deleted successfully.")
         else:
             logger.error(f"Failed to delete secret key for {selected.fingerprint}.")
-            logger.debug(f"Output: {result_secret.stdout}") # type: ignore
-            logger.debug(f"Error: {result_secret.stderr}") # type: ignore
-
+            logger.debug(f"Output: {result_secret.stdout}")  # type: ignore
+            logger.debug(f"Error: {result_secret.stderr}")  # type: ignore
 
         if not secret_only:
             logger.info(f"Attempting to delete public key for {selected.fingerprint}...")
             gpg_cmd_public = '{} -q --batch --delete-key {}'.format(self.gpg.getbin(), selected.fingerprint)
             result_public = invoke.run(gpg_cmd_public, env=self.gpg.getenv(), pty=True, hide=True)
-            if result_public.ok: # type: ignore
+            if result_public.ok:  # type: ignore
                 logger.success(f"Public key for {selected.fingerprint} deleted successfully.")
             else:
                 logger.error(f"Failed to delete public key for {selected.fingerprint}.")
-                logger.debug(f"Output: {result_public.stdout}") # type: ignore
-                logger.debug(f"Error: {result_public.stderr}") # type: ignore
+                logger.debug(f"Output: {result_public.stdout}")  # type: ignore
+                logger.debug(f"Error: {result_public.stderr}")  # type: ignore
         else:
             logger.info(f"Skipping public key deletion for {selected.fingerprint} as per --secret flag.")
 

--- a/secureenclave/secureenclave.py
+++ b/secureenclave/secureenclave.py
@@ -264,13 +264,40 @@ class SecureEnclave(object):
         logger.success('GPG Key creation completed, including all subkeys. Use "key list" to explore.')
         return True
 
-    def del_key(self):
+    def del_key(self, secret_only=False):
         keys = self.gpg.get_keys()
+        if not keys:
+            logger.info("No keys available to delete.")
+            return
+
         selected = Bullet('Select which key to delete: ', keys).launch()  # type:ignore
-        gpg_cmd = '{} -q --batch --delete-secret-key {}'.format(self.gpg.getbin(), selected.fingerprint)
-        invoke.run(gpg_cmd, env=self.gpg.getenv(), pty=True)
-        gpg_cmd = '{} -q --batch --delete-key {}'.format(self.gpg.getbin(), selected.fingerprint)
-        invoke.run(gpg_cmd, env=self.gpg.getenv(), pty=True)
+        if not selected:
+            logger.info("Key deletion cancelled.")
+            return
+
+        logger.info(f"Attempting to delete secret key for {selected.fingerprint}...")
+        gpg_cmd_secret = '{} -q --batch --delete-secret-key {}'.format(self.gpg.getbin(), selected.fingerprint)
+        result_secret = invoke.run(gpg_cmd_secret, env=self.gpg.getenv(), pty=True, hide=True)
+        if result_secret.ok: # type: ignore
+            logger.success(f"Secret key for {selected.fingerprint} deleted successfully.")
+        else:
+            logger.error(f"Failed to delete secret key for {selected.fingerprint}.")
+            logger.debug(f"Output: {result_secret.stdout}") # type: ignore
+            logger.debug(f"Error: {result_secret.stderr}") # type: ignore
+
+
+        if not secret_only:
+            logger.info(f"Attempting to delete public key for {selected.fingerprint}...")
+            gpg_cmd_public = '{} -q --batch --delete-key {}'.format(self.gpg.getbin(), selected.fingerprint)
+            result_public = invoke.run(gpg_cmd_public, env=self.gpg.getenv(), pty=True, hide=True)
+            if result_public.ok: # type: ignore
+                logger.success(f"Public key for {selected.fingerprint} deleted successfully.")
+            else:
+                logger.error(f"Failed to delete public key for {selected.fingerprint}.")
+                logger.debug(f"Output: {result_public.stdout}") # type: ignore
+                logger.debug(f"Error: {result_public.stderr}") # type: ignore
+        else:
+            logger.info(f"Skipping public key deletion for {selected.fingerprint} as per --secret flag.")
 
     def encrypt(self, input, output):
         key_list = self.gpg.get_keys()

--- a/secureenclave/secureenclave.py
+++ b/secureenclave/secureenclave.py
@@ -204,7 +204,7 @@ class SecureEnclave(object):
     def list_keys(self):
         """List keys on smartcard"""
         logger.info('Public keys')
-        gpg_cmd = '{} --list-keys --with-keygrip'.format(self.gpg.getbin())
+        gpg_cmd = '{} --list-keys --with-colons --fixed-list-mode --with-fingerprint --with-keygrip'.format(self.gpg.getbin())
         invoke.run(gpg_cmd, env=self.gpg.getenv(), pty=True)
         logger.info('Private keys')
         gpg_cmd = '{} --list-secret-keys'.format(self.gpg.getbin())


### PR DESCRIPTION
- **refactor: Extract parsing logic to _parse_gpg_list_cmd method**
- **feat: Refactor GPG key parsing to use colon-delimited output.**
- **style: Fix linting errors in datamodel.py and gpg.py**
- **refactor: Improve GPG key parsing and data model for clarity**
- **feat: Parse GPG subkeys and add them to GpgKey object**
- **style: Fix linting errors in secureenclave/gpg.py**
- **refactor: Simplify GPG key parsing and command execution**
- **feat: Enhance GPG key parsing to identify secret keys and subkeys**
- **refactor: Parse secret keys and subkeys from GPG output**
- **style: Fix linting errors in secureenclave/gpg.py**
- **feat: Update key_list command to use get_keys and print key details**
- **style: Fix linting errors in cli_keycmds.py**
- **refactor: Simplify GPG key parsing and logging in Gpg class**
- **fix: Call gpg list-keys and list-secret-keys separately**
- **refactor: Deduplicate GPG keys and add secret_available flag.**
- **fix: Correct indentation error in gpg.py and remove redundant code**
- **style: Fix linting issues in secureenclave/gpg.py**
- **style: Fix E303 too many blank lines in secureenclave/gpg.py**
- **refactor: Simplify GPG key retrieval and parsing logic**
- **feat: Implement _dedup_keys to merge public and secret GPG keys**
- **fix: resolve flake8 linting errors in gpg.py**
- **fix: Use secret_available instead of is_secret for key type check**
- **feat: Add --secret flag to key del command to delete only secret key**
- **style: Fix flake8 errors: spacing and blank lines in secureenclave.py**
- **removed some unnecessary comments**
